### PR TITLE
fix: introspection bugs (array detection, enum conflicts, unknown type warnings)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,7 +107,7 @@ async function generate(options: {
 
   // Transform and generate
   spinner.start('Generating TypeScript types...');
-  const program = transformDatabase(metadata, {
+  const { program, warnings } = transformDatabase(metadata, {
     camelCase: options.camelCase,
     includePattern: options.includePattern.length > 0 ? options.includePattern : undefined,
     excludePattern: options.excludePattern.length > 0 ? options.excludePattern : undefined,
@@ -119,11 +119,20 @@ async function generate(options: {
   await writeFile(absolutePath, code, 'utf-8');
   spinner.succeed(`Types written to ${chalk.cyan(absolutePath)}`);
 
+  // Show warnings
+  if (warnings.length > 0) {
+    console.log('');
+    console.log(chalk.yellow('Warnings:'));
+    for (const w of warnings) {
+      console.log(chalk.dim(`  Unknown type '${w.pgType}' mapped to 'unknown'`));
+    }
+  }
+
   // Clean up
   await db.destroy();
 
   console.log('');
-  console.log(chalk.green('✓ Done!'));
+  console.log(chalk.green('Done!'));
   console.log('');
 }
 

--- a/src/transform/enum.ts
+++ b/src/transform/enum.ts
@@ -1,10 +1,18 @@
 import type { TypeAliasNode } from '@/ast/nodes';
+import type { EnumMetadata } from '@/introspect/types';
 import { toPascalCase } from '@/transform/utils';
 
-export function transformEnum(enumMetadata: { name: string; values: string[] }): TypeAliasNode {
+export function getEnumTypeName(enumMeta: EnumMetadata, defaultSchema = 'public'): string {
+  if (enumMeta.schema === defaultSchema) {
+    return toPascalCase(enumMeta.name);
+  }
+  return toPascalCase(enumMeta.schema) + toPascalCase(enumMeta.name);
+}
+
+export function transformEnum(enumMetadata: EnumMetadata, defaultSchema = 'public'): TypeAliasNode {
   return {
     kind: 'typeAlias',
-    name: toPascalCase(enumMetadata.name),
+    name: getEnumTypeName(enumMetadata, defaultSchema),
     type: {
       kind: 'union',
       types: enumMetadata.values.map((value) => ({

--- a/src/transform/table.ts
+++ b/src/transform/table.ts
@@ -1,16 +1,20 @@
 import type { InterfaceNode, PropertyNode, TypeNode } from '@/ast/nodes';
-import type { ColumnMetadata, TableMetadata } from '@/introspect/types';
+import type { ColumnMetadata, EnumMetadata, TableMetadata } from '@/introspect/types';
 import { toCamelCase } from '@/utils/case-converter';
 import type { TransformOptions } from '@/transform/types';
 import { mapPostgresType } from '@/transform/type-mapper';
 import { toPascalCase, singularize } from '@/transform/utils';
+import { getEnumTypeName } from '@/transform/enum';
 
 export function transformTable(
   table: TableMetadata,
-  enums: { name: string; values: string[] }[],
-  options?: TransformOptions
+  enums: EnumMetadata[],
+  options?: TransformOptions,
+  unknownTypes?: Set<string>
 ): InterfaceNode {
-  const properties: PropertyNode[] = table.columns.map((column) => transformColumn(column, enums, options));
+  const properties: PropertyNode[] = table.columns.map((column) =>
+    transformColumn(column, enums, options, unknownTypes)
+  );
 
   return {
     kind: 'interface',
@@ -22,14 +26,17 @@ export function transformTable(
 
 export function transformColumn(
   column: ColumnMetadata,
-  enums: { name: string; values: string[] }[],
-  options?: TransformOptions
+  enums: EnumMetadata[],
+  options?: TransformOptions,
+  unknownTypes?: Set<string>
 ): PropertyNode {
-  const matchingEnum = enums.find((e) => e.name === column.dataType);
+  const matchingEnum = enums.find(
+    (e) => e.name === column.dataType && e.schema === (column.dataTypeSchema ?? 'public')
+  );
 
   let type: TypeNode;
   if (matchingEnum) {
-    const enumTypeName = toPascalCase(matchingEnum.name);
+    const enumTypeName = getEnumTypeName(matchingEnum);
     type = { kind: 'reference', name: enumTypeName };
 
     if (column.isNullable) {
@@ -39,7 +46,7 @@ export function transformColumn(
       };
     }
   } else {
-    type = mapPostgresType(column.dataType, column.isNullable, column.isArray);
+    type = mapPostgresType(column.dataType, column.isNullable, column.isArray, unknownTypes);
   }
 
   if (column.isAutoIncrement) {

--- a/src/transform/type-mapper.ts
+++ b/src/transform/type-mapper.ts
@@ -22,10 +22,15 @@ function createColumnType(
   };
 }
 
-export function mapPostgresType(pgType: string, isNullable: boolean, isArray?: boolean): TypeNode {
+export function mapPostgresType(
+  pgType: string,
+  isNullable: boolean,
+  isArray?: boolean,
+  unknownTypes?: Set<string>
+): TypeNode {
   if (isArray || pgType.endsWith('[]')) {
     const baseTypeName = pgType.endsWith('[]') ? pgType.slice(0, -2) : pgType;
-    const elementType = mapPostgresType(baseTypeName, false, false);
+    const elementType = mapPostgresType(baseTypeName, false, false, unknownTypes);
     const arrayType: TypeNode = {
       kind: 'array',
       elementType,
@@ -152,6 +157,9 @@ export function mapPostgresType(pgType: string, isNullable: boolean, isArray?: b
       break;
 
     default:
+      if (unknownTypes) {
+        unknownTypes.add(pgType);
+      }
       baseType = { kind: 'primitive', value: 'unknown' };
   }
 

--- a/src/transform/types.ts
+++ b/src/transform/types.ts
@@ -1,5 +1,17 @@
+import type { ProgramNode } from '@/ast/nodes';
+
 export type TransformOptions = {
   camelCase?: boolean;
   includePattern?: string[];
   excludePattern?: string[];
+};
+
+export type TransformWarning = {
+  type: 'unknown_type';
+  pgType: string;
+};
+
+export type TransformResult = {
+  program: ProgramNode;
+  warnings: TransformWarning[];
 };

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -67,6 +67,12 @@ export interface UserStat {
   comment_count: ColumnType<string, string | number | bigint, string | number | bigint> | null;
 }
 
+export interface UserTagsView {
+  id: number | null;
+  username: string | null;
+  tags: string[] | null;
+}
+
 export interface DB {
   comments: Comment;
   measurements: Measurement;
@@ -75,6 +81,7 @@ export interface DB {
   posts: Post;
   users: User;
   user_stats: UserStat;
+  user_tags_view: UserTagsView;
 }
 "
 `;

--- a/test/camelcase.test.ts
+++ b/test/camelcase.test.ts
@@ -66,7 +66,7 @@ describe('CamelCase Support', () => {
     };
 
     test('should convert column names to camelCase', () => {
-      const program = transformDatabase(metadata, { camelCase: true });
+      const { program } = transformDatabase(metadata, { camelCase: true });
       const code = serialize(program);
 
       expect(code).toContain('userId: Generated<number>');
@@ -76,21 +76,21 @@ describe('CamelCase Support', () => {
     });
 
     test('should convert table names in DB interface to camelCase', () => {
-      const program = transformDatabase(metadata, { camelCase: true });
+      const { program } = transformDatabase(metadata, { camelCase: true });
       const code = serialize(program);
 
       expect(code).toContain('userProfiles: UserProfile');
     });
 
     test('should keep interface names as PascalCase', () => {
-      const program = transformDatabase(metadata, { camelCase: true });
+      const { program } = transformDatabase(metadata, { camelCase: true });
       const code = serialize(program);
 
       expect(code).toContain('export interface UserProfile {');
     });
 
     test('should not convert names when camelCase is false', () => {
-      const program = transformDatabase(metadata, { camelCase: false });
+      const { program } = transformDatabase(metadata, { camelCase: false });
       const code = serialize(program);
 
       expect(code).toContain('user_id: Generated<number>');
@@ -99,7 +99,7 @@ describe('CamelCase Support', () => {
     });
 
     test('should not convert names when camelCase is undefined', () => {
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
       const code = serialize(program);
 
       expect(code).toContain('user_id: Generated<number>');
@@ -133,7 +133,7 @@ describe('CamelCase Support', () => {
         ],
       };
 
-      const program = transformDatabase(metadataWithEnum, { camelCase: true });
+      const { program } = transformDatabase(metadataWithEnum, { camelCase: true });
       const code = serialize(program);
 
       expect(code).toContain('accountStatus: StatusEnum');
@@ -159,7 +159,7 @@ describe('CamelCase Support', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadataWithNullable, { camelCase: true });
+      const { program } = transformDatabase(metadataWithNullable, { camelCase: true });
       const code = serialize(program);
 
       expect(code).toContain('middleName: string | null');

--- a/test/fixtures/init.sql
+++ b/test/fixtures/init.sql
@@ -73,6 +73,16 @@ GROUP BY u.id, u.username;
 
 CREATE INDEX ON user_stats (id);
 
+-- Materialized view with array column (for Bug 2 test)
+CREATE MATERIALIZED VIEW user_tags_view AS
+SELECT
+  u.id,
+  u.username,
+  u.tags
+FROM users u;
+
+CREATE INDEX ON user_tags_view (id);
+
 -- Create partitioned table
 CREATE TABLE measurements (
   id SERIAL,

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -24,7 +24,7 @@ describe('Integration: Full pipeline', () => {
     const metadata = await introspectDatabase(db, { schemas: ['public'] });
 
     // Transform
-    const program = transformDatabase(metadata);
+    const { program } = transformDatabase(metadata);
 
     // Serialize
     const output = serialize(program);
@@ -63,7 +63,7 @@ describe('Integration: Full pipeline', () => {
     expect(metadata.tables).toHaveLength(0);
     expect(metadata.enums).toHaveLength(0);
 
-    const program = transformDatabase(metadata);
+    const { program } = transformDatabase(metadata);
     const output = serialize(program);
 
     // Should still have imports and DB interface

--- a/test/introspect/postgres.test.ts
+++ b/test/introspect/postgres.test.ts
@@ -196,4 +196,17 @@ describe('PostgreSQL Introspector', () => {
     expect(partition2).toBeDefined();
     expect(partition2?.isPartition).toBe(true);
   });
+
+  test('should detect array columns in materialized views', async () => {
+    const metadata = await introspectDatabase(db, { schemas: ['public'] });
+
+    const userTagsView = metadata.tables.find((t) => t.name === 'user_tags_view');
+    expect(userTagsView).toBeDefined();
+    expect(userTagsView?.isView).toBe(true);
+
+    const tagsColumn = userTagsView?.columns.find((c) => c.name === 'tags');
+    expect(tagsColumn).toBeDefined();
+    expect(tagsColumn?.isArray).toBe(true);
+    expect(tagsColumn?.dataType).toBe('text');
+  });
 });

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -87,7 +87,7 @@ describe('Transform', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       // Should have import, Generated type, and 2 interfaces (User + DB)
       expect(program.declarations).toHaveLength(4);
@@ -146,7 +146,7 @@ describe('Transform', () => {
         ],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const statusType = program.declarations.find(
         (d) => d.kind === 'typeAlias' && d.name === 'StatusEnum'
@@ -183,7 +183,7 @@ describe('Transform', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const postInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'Post'
@@ -230,7 +230,7 @@ describe('Transform', () => {
         ],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const commentInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'Comment'
@@ -270,7 +270,7 @@ describe('Transform', () => {
         ],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const commentInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'Comment'
@@ -324,7 +324,7 @@ describe('Transform', () => {
     };
 
     test('should include only matching tables with include pattern', () => {
-      const program = transformDatabase(testMetadata, {
+      const { program } = transformDatabase(testMetadata, {
         includePattern: ['public.user*'],
       });
 
@@ -334,7 +334,7 @@ describe('Transform', () => {
     });
 
     test('should exclude matching tables with exclude pattern', () => {
-      const program = transformDatabase(testMetadata, {
+      const { program } = transformDatabase(testMetadata, {
         excludePattern: ['*internal*'],
       });
 
@@ -349,7 +349,7 @@ describe('Transform', () => {
     });
 
     test('should handle multiple include patterns', () => {
-      const program = transformDatabase(testMetadata, {
+      const { program } = transformDatabase(testMetadata, {
         includePattern: ['public.users', 'auth.*'],
       });
 
@@ -362,7 +362,7 @@ describe('Transform', () => {
     });
 
     test('should combine include and exclude patterns', () => {
-      const program = transformDatabase(testMetadata, {
+      const { program } = transformDatabase(testMetadata, {
         includePattern: ['public.*'],
         excludePattern: ['*internal*'],
       });
@@ -377,7 +377,7 @@ describe('Transform', () => {
     });
 
     test('should update DB interface with filtered tables only', () => {
-      const program = transformDatabase(testMetadata, {
+      const { program } = transformDatabase(testMetadata, {
         includePattern: ['public.users'],
       });
 
@@ -491,7 +491,7 @@ describe('Transform', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const productInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'Product'
@@ -652,7 +652,7 @@ describe('Transform', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const complexInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'ComplexType'
@@ -696,7 +696,7 @@ describe('Transform', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const simpleInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'Simple'
@@ -715,7 +715,7 @@ describe('Transform', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const dbInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'DB'
@@ -761,7 +761,7 @@ describe('Transform', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const typeInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'Type'
@@ -804,7 +804,7 @@ describe('Transform', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const specialInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'Special'
@@ -838,7 +838,7 @@ describe('Transform', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const tableInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'Table123'
@@ -881,7 +881,7 @@ describe('Transform', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const nullableInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'NullableTable'
@@ -908,7 +908,7 @@ describe('Transform', () => {
         ],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const singleEnum = program.declarations.find(
         (d) => d.kind === 'typeAlias' && d.name === 'SingleEnum'
@@ -944,7 +944,7 @@ describe('Transform', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const longInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'VeryLongTableNameThatGoesOnAndOnAndOn'
@@ -980,7 +980,7 @@ describe('Transform', () => {
         enums: [],
       };
 
-      const program = transformDatabase(metadata);
+      const { program } = transformDatabase(metadata);
 
       const defaultInterface = program.declarations.find(
         (d) => d.kind === 'interface' && d.name === 'Default'
@@ -997,6 +997,201 @@ describe('Transform', () => {
           expect(createdProp.type.name).toBe('ColumnType');
         }
       }
+    });
+  });
+
+  describe('schema-qualified enums', () => {
+    test('should prefix enum type names with schema for non-public schemas', () => {
+      const metadata: DatabaseMetadata = {
+        tables: [],
+        enums: [
+          {
+            schema: 'public',
+            name: 'status_enum',
+            values: ['pending', 'approved'],
+          },
+          {
+            schema: 'auth',
+            name: 'role_enum',
+            values: ['admin', 'user'],
+          },
+        ],
+      };
+
+      const { program } = transformDatabase(metadata);
+
+      const publicEnum = program.declarations.find(
+        (d) => d.kind === 'typeAlias' && d.name === 'StatusEnum'
+      );
+      expect(publicEnum).toBeDefined();
+
+      const authEnum = program.declarations.find(
+        (d) => d.kind === 'typeAlias' && d.name === 'AuthRoleEnum'
+      );
+      expect(authEnum).toBeDefined();
+    });
+
+    test('should correctly reference schema-qualified enum in column type', () => {
+      const metadata: DatabaseMetadata = {
+        tables: [
+          {
+            schema: 'auth',
+            name: 'users',
+            columns: [
+              {
+                name: 'id',
+                dataType: 'int4',
+                isNullable: false,
+                isAutoIncrement: true,
+                hasDefaultValue: true,
+              },
+              {
+                name: 'role',
+                dataType: 'role_enum',
+                dataTypeSchema: 'auth',
+                isNullable: false,
+                isAutoIncrement: false,
+                hasDefaultValue: false,
+              },
+            ],
+          },
+        ],
+        enums: [
+          {
+            schema: 'auth',
+            name: 'role_enum',
+            values: ['admin', 'user'],
+          },
+        ],
+      };
+
+      const { program } = transformDatabase(metadata);
+
+      const userInterface = program.declarations.find(
+        (d) => d.kind === 'interface' && d.name === 'User'
+      );
+      expect(userInterface).toBeDefined();
+      if (userInterface?.kind === 'interface') {
+        const roleProp = userInterface.properties.find((p) => p.name === 'role');
+        expect(roleProp?.type).toEqual({ kind: 'reference', name: 'AuthRoleEnum' });
+      }
+    });
+  });
+
+  describe('unknown type warnings', () => {
+    test('should return warnings for unknown postgres types', () => {
+      const metadata: DatabaseMetadata = {
+        tables: [
+          {
+            schema: 'public',
+            name: 'test',
+            columns: [
+              {
+                name: 'id',
+                dataType: 'int4',
+                isNullable: false,
+                isAutoIncrement: true,
+                hasDefaultValue: true,
+              },
+              {
+                name: 'geo',
+                dataType: 'geometry',
+                isNullable: false,
+                isAutoIncrement: false,
+                hasDefaultValue: false,
+              },
+              {
+                name: 'network',
+                dataType: 'inet',
+                isNullable: false,
+                isAutoIncrement: false,
+                hasDefaultValue: false,
+              },
+            ],
+          },
+        ],
+        enums: [],
+      };
+
+      const result = transformDatabase(metadata);
+
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings.length).toBeGreaterThan(0);
+
+      const unknownTypes = result.warnings.map((w) => w.pgType);
+      expect(unknownTypes).toContain('geometry');
+      expect(unknownTypes).toContain('inet');
+    });
+
+    test('should dedupe warnings by type', () => {
+      const metadata: DatabaseMetadata = {
+        tables: [
+          {
+            schema: 'public',
+            name: 'test1',
+            columns: [
+              {
+                name: 'geo1',
+                dataType: 'geometry',
+                isNullable: false,
+                isAutoIncrement: false,
+                hasDefaultValue: false,
+              },
+            ],
+          },
+          {
+            schema: 'public',
+            name: 'test2',
+            columns: [
+              {
+                name: 'geo2',
+                dataType: 'geometry',
+                isNullable: false,
+                isAutoIncrement: false,
+                hasDefaultValue: false,
+              },
+            ],
+          },
+        ],
+        enums: [],
+      };
+
+      const result = transformDatabase(metadata);
+
+      const geometryWarnings = result.warnings.filter((w) => w.pgType === 'geometry');
+      expect(geometryWarnings).toHaveLength(1);
+    });
+
+    test('should return empty warnings for known types', () => {
+      const metadata: DatabaseMetadata = {
+        tables: [
+          {
+            schema: 'public',
+            name: 'test',
+            columns: [
+              {
+                name: 'id',
+                dataType: 'int4',
+                isNullable: false,
+                isAutoIncrement: true,
+                hasDefaultValue: true,
+              },
+              {
+                name: 'name',
+                dataType: 'varchar',
+                isNullable: false,
+                isAutoIncrement: false,
+                hasDefaultValue: false,
+              },
+            ],
+          },
+        ],
+        enums: [],
+      };
+
+      const result = transformDatabase(metadata);
+
+      expect(result.warnings).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fix materialized view array detection to use `pg_type.typcategory = 'A'` instead of checking for underscore prefix
- Add schema-qualified enum type names (`auth.status` -> `AuthStatus`, `public.status` -> `Status`)
- Return warnings for unknown postgres types from `transformDatabase()`
- **BREAKING**: `transformDatabase()` now returns `{ program, warnings }` instead of `ProgramNode`

## Changes

| Bug | Status | Fix |
|-----|--------|-----|
| #1 Partition detection | Not a bug | Verified with tests |
| #2 Array detection inconsistency | Fixed | Use `typcategory = 'A'` |
| #3 Schema-qualified enum conflicts | Fixed | Prefix non-public enums |
| #4 Silent unknown type return | Fixed | Return warnings array |

## Test plan

- [x] All 115 tests pass
- [x] Added test for matview array detection
- [x] Added tests for schema-qualified enums
- [x] Added tests for unknown type warnings

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)