### PR TITLE
feat: add E2E integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,13 @@
     "build": "bun build ./src/cli.ts --outdir ./dist --target node",
     "test": "bun test",
     "test:watch": "bun test --watch",
+    "test:e2e": "bun test test/e2e/",
     "test:integration": "docker compose up -d && bun test --timeout 10000 && docker compose down",
     "dev": "bun run src/cli.ts",
     "db:up": "docker compose up -d",
     "db:down": "docker compose down",
-    "db:logs": "docker compose logs -f postgres"
+    "db:logs": "docker compose logs -f postgres",
+    "types:generate": "DATABASE_URL=postgres://test_user:test_password@localhost:5433/test_db bun run dev --out test/fixtures/generated-types.ts && DATABASE_URL=postgres://test_user:test_password@localhost:5433/test_db bun run dev --camel-case --out test/fixtures/generated-types-camel.ts"
   },
   "dependencies": {
     "chalk": "^5.6.2",

--- a/test/e2e/queries.test.ts
+++ b/test/e2e/queries.test.ts
@@ -1,0 +1,210 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { CamelCasePlugin, Kysely, PostgresDialect, sql, type Insertable, type Updateable } from 'kysely';
+import { Pool } from 'pg';
+import type { DB, User, StatusEnum } from '../fixtures/generated-types';
+import type { DB as CamelDB, User as CamelUser } from '../fixtures/generated-types-camel';
+
+const TEST_DATABASE_URL = 'postgres://test_user:test_password@localhost:5433/test_db';
+
+describe('E2E: Queries', () => {
+  let db: Kysely<DB>;
+  let camelDb: Kysely<CamelDB>;
+
+  beforeAll(async () => {
+    db = new Kysely<DB>({
+      dialect: new PostgresDialect({ pool: new Pool({ connectionString: TEST_DATABASE_URL }) }),
+    });
+    camelDb = new Kysely<CamelDB>({
+      dialect: new PostgresDialect({ pool: new Pool({ connectionString: TEST_DATABASE_URL }) }),
+      plugins: [new CamelCasePlugin()],
+    });
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+    await camelDb.destroy();
+  });
+
+  beforeEach(async () => {
+    await db.deleteFrom('comments').execute();
+    await db.deleteFrom('posts').execute();
+    await db.deleteFrom('users').execute();
+  });
+
+  describe('snake_case types', () => {
+    describe('SELECT', () => {
+      test('selectAll', async () => {
+        await db.insertInto('users').values({ email: 'test@example.com', username: 'testuser' }).execute();
+        const users = await db.selectFrom('users').selectAll().execute();
+
+        expect(users.length).toBe(1);
+        expect(users[0].email).toBe('test@example.com');
+      });
+
+      test('select specific columns', async () => {
+        await db.insertInto('users').values({ email: 'test@example.com', username: 'testuser' }).execute();
+        const result = await db.selectFrom('users').select(['id', 'email', 'is_active']).executeTakeFirst();
+
+        expect(typeof result!.id).toBe('number');
+        expect(typeof result!.email).toBe('string');
+        expect(typeof result!.is_active).toBe('boolean');
+      });
+
+      test('nullable columns', async () => {
+        await db.insertInto('users').values({ email: 'test@example.com', username: 'testuser' }).execute();
+        const result = await db.selectFrom('users').select(['updated_at', 'metadata']).executeTakeFirst();
+
+        expect(result!.updated_at).toBeNull();
+        expect(result!.metadata).toBeNull();
+      });
+    });
+
+    describe('INSERT', () => {
+      test('Generated columns are optional', async () => {
+        const newUser: Insertable<User> = { email: 'test@example.com', username: 'testuser' };
+        const result = await db.insertInto('users').values(newUser).returning(['id', 'created_at']).executeTakeFirstOrThrow();
+
+        expect(result.id).toBeGreaterThan(0);
+        expect(result.created_at).toBeInstanceOf(Date);
+      });
+
+      test('string accepted for Date fields (ColumnType)', async () => {
+        const result = await db
+          .insertInto('users')
+          .values({ email: 'test@example.com', username: 'testuser', created_at: '2024-01-01T00:00:00Z' })
+          .returning('created_at')
+          .executeTakeFirstOrThrow();
+
+        expect(result.created_at).toBeInstanceOf(Date);
+      });
+
+      test('enum columns', async () => {
+        const user = await db.insertInto('users').values({ email: 'test@example.com', username: 'testuser' }).returning('id').executeTakeFirstOrThrow();
+        const post = await db.insertInto('posts').values({ user_id: user.id, title: 'Post' }).returning('id').executeTakeFirstOrThrow();
+
+        const status: StatusEnum = 'approved';
+        const comment = await db
+          .insertInto('comments')
+          .values({ post_id: post.id, user_id: user.id, content: 'Comment', status })
+          .returning('status')
+          .executeTakeFirstOrThrow();
+
+        expect(comment.status).toBe('approved');
+      });
+
+      test('array columns', async () => {
+        const result = await db
+          .insertInto('users')
+          .values({ email: 'test@example.com', username: 'testuser', tags: ['a', 'b'], scores: [1, 2, 3] })
+          .returning(['tags', 'scores'])
+          .executeTakeFirstOrThrow();
+
+        expect(result.tags).toEqual(['a', 'b']);
+        expect(result.scores).toEqual([1, 2, 3]);
+      });
+    });
+
+    describe('UPDATE', () => {
+      test('Updateable type', async () => {
+        const user = await db.insertInto('users').values({ email: 'test@example.com', username: 'testuser' }).returning('id').executeTakeFirstOrThrow();
+
+        const update: Updateable<User> = { username: 'updated', updated_at: new Date() };
+        const result = await db.updateTable('users').set(update).where('id', '=', user.id).returning(['username', 'updated_at']).executeTakeFirstOrThrow();
+
+        expect(result.username).toBe('updated');
+        expect(result.updated_at).toBeInstanceOf(Date);
+      });
+    });
+
+    describe('JOIN', () => {
+      test('inner join', async () => {
+        const user = await db.insertInto('users').values({ email: 'test@example.com', username: 'testuser' }).returning('id').executeTakeFirstOrThrow();
+        await db.insertInto('posts').values({ user_id: user.id, title: 'Post' }).execute();
+
+        const result = await db
+          .selectFrom('users')
+          .innerJoin('posts', 'posts.user_id', 'users.id')
+          .select(['users.email', 'posts.title'])
+          .executeTakeFirst();
+
+        expect(result?.email).toBe('test@example.com');
+        expect(result?.title).toBe('Post');
+      });
+
+      test('three-way join', async () => {
+        const user = await db.insertInto('users').values({ email: 'test@example.com', username: 'testuser' }).returning('id').executeTakeFirstOrThrow();
+        const post = await db.insertInto('posts').values({ user_id: user.id, title: 'Post' }).returning('id').executeTakeFirstOrThrow();
+        await db.insertInto('comments').values({ post_id: post.id, user_id: user.id, content: 'Comment', status: 'pending' }).execute();
+
+        const result = await db
+          .selectFrom('users')
+          .innerJoin('posts', 'posts.user_id', 'users.id')
+          .innerJoin('comments', 'comments.post_id', 'posts.id')
+          .select(['users.username', 'posts.title', 'comments.content'])
+          .executeTakeFirst();
+
+        expect(result?.username).toBe('testuser');
+        expect(result?.title).toBe('Post');
+        expect(result?.content).toBe('Comment');
+      });
+    });
+
+    describe('Views', () => {
+      test('materialized view', async () => {
+        const user = await db.insertInto('users').values({ email: 'test@example.com', username: 'viewuser' }).returning('id').executeTakeFirstOrThrow();
+        await db.insertInto('posts').values({ user_id: user.id, title: 'Post 1' }).execute();
+        await db.insertInto('posts').values({ user_id: user.id, title: 'Post 2' }).execute();
+
+        await sql`REFRESH MATERIALIZED VIEW user_stats`.execute(db);
+
+        const stats = await db.selectFrom('user_stats').selectAll().where('username', '=', 'viewuser').executeTakeFirst();
+
+        expect(stats?.post_count).toBe('2');
+      });
+    });
+  });
+
+  describe('camelCase types', () => {
+    test('select with camelCase column names', async () => {
+      await camelDb.insertInto('users').values({ email: 'test@example.com', username: 'testuser' }).execute();
+      const user = await camelDb.selectFrom('users').select(['id', 'email', 'isActive', 'createdAt']).executeTakeFirst();
+
+      expect(user!.isActive).toBe(true);
+      expect(user!.createdAt).toBeInstanceOf(Date);
+    });
+
+    test('insert with camelCase column names', async () => {
+      const newUser: Insertable<CamelUser> = { email: 'test@example.com', username: 'testuser' };
+      const result = await camelDb.insertInto('users').values(newUser).returning(['id', 'createdAt', 'isActive']).executeTakeFirstOrThrow();
+
+      expect(result.id).toBeGreaterThan(0);
+      expect(result.createdAt).toBeInstanceOf(Date);
+      expect(result.isActive).toBe(true);
+    });
+
+    test('join with camelCase foreign keys', async () => {
+      const user = await camelDb.insertInto('users').values({ email: 'test@example.com', username: 'testuser' }).returning('id').executeTakeFirstOrThrow();
+      await camelDb.insertInto('posts').values({ userId: user.id, title: 'Post' }).execute();
+
+      const result = await camelDb
+        .selectFrom('users')
+        .innerJoin('posts', 'posts.userId', 'users.id')
+        .select(['users.email', 'posts.title', 'posts.viewCount'])
+        .executeTakeFirst();
+
+      expect(result?.email).toBe('test@example.com');
+      expect(result?.title).toBe('Post');
+      expect(result?.viewCount).toBe(0);
+    });
+
+    test('update with camelCase column names', async () => {
+      const user = await camelDb.insertInto('users').values({ email: 'test@example.com', username: 'testuser' }).returning('id').executeTakeFirstOrThrow();
+
+      const update: Updateable<CamelUser> = { username: 'updated', updatedAt: new Date() };
+      const result = await camelDb.updateTable('users').set(update).where('id', '=', user.id).returning(['username', 'updatedAt']).executeTakeFirstOrThrow();
+
+      expect(result.username).toBe('updated');
+      expect(result.updatedAt).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/test/e2e/sync.test.ts
+++ b/test/e2e/sync.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { Kysely, PostgresDialect } from 'kysely';
+import { Pool } from 'pg';
+import { serialize } from '@/ast/serialize';
+import { introspectDatabase } from '@/introspect/postgres';
+import { transformDatabase } from '@/transform';
+
+const TEST_DATABASE_URL = 'postgres://test_user:test_password@localhost:5433/test_db';
+
+describe('E2E: Types sync', () => {
+  let db: Kysely<any>;
+
+  beforeAll(async () => {
+    const pool = new Pool({ connectionString: TEST_DATABASE_URL });
+    db = new Kysely({ dialect: new PostgresDialect({ pool }) });
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  test('generated-types.ts matches current tool output', async () => {
+    const metadata = await introspectDatabase(db, { schemas: ['public'] });
+    const { program } = transformDatabase(metadata);
+    const freshOutput = serialize(program);
+
+    const committedTypes = await Bun.file('test/fixtures/generated-types.ts').text();
+
+    expect(freshOutput.trim()).toBe(committedTypes.trim());
+  });
+
+  test('generated-types-camel.ts matches current tool output', async () => {
+    const metadata = await introspectDatabase(db, { schemas: ['public'] });
+    const { program } = transformDatabase(metadata, { camelCase: true });
+    const freshOutput = serialize(program);
+
+    const committedTypes = await Bun.file('test/fixtures/generated-types-camel.ts').text();
+
+    expect(freshOutput.trim()).toBe(committedTypes.trim());
+  });
+});

--- a/test/e2e/type-errors.test.ts
+++ b/test/e2e/type-errors.test.ts
@@ -1,0 +1,83 @@
+import { describe, test } from 'bun:test';
+import { Kysely, PostgresDialect, type Insertable } from 'kysely';
+import { Pool } from 'pg';
+import type { DB, User, StatusEnum } from '../fixtures/generated-types';
+
+const TEST_DATABASE_URL = 'postgres://test_user:test_password@localhost:5433/test_db';
+
+describe('E2E: Type errors caught at compile time', () => {
+  const db = new Kysely<DB>({
+    dialect: new PostgresDialect({
+      pool: new Pool({ connectionString: TEST_DATABASE_URL }),
+    }),
+  });
+
+  test('invalid table name rejected', () => {
+    // @ts-expect-error - 'nonexistent' is not a valid table
+    db.selectFrom('nonexistent');
+  });
+
+  test('invalid column name rejected', () => {
+    db.selectFrom('users')
+      // @ts-expect-error - 'nonexistent_column' does not exist on users
+      .select('nonexistent_column');
+  });
+
+  test('wrong type for boolean column rejected', () => {
+    const badInsert: Insertable<User> = {
+      email: 'test@example.com',
+      username: 'test',
+      // @ts-expect-error - is_active should be boolean, not string
+      is_active: 'yes',
+    };
+    void badInsert;
+  });
+
+  test('wrong type for string column rejected', () => {
+    const badInsert: Insertable<User> = {
+      // @ts-expect-error - email should be string, not number
+      email: 123,
+      username: 'test',
+    };
+    void badInsert;
+  });
+
+  test('missing required field rejected', () => {
+    // @ts-expect-error - email is required
+    const badInsert: Insertable<User> = {
+      username: 'test',
+    };
+    void badInsert;
+  });
+
+  test('wrong enum value rejected', () => {
+    // @ts-expect-error - 'invalid_status' is not in StatusEnum
+    const status: StatusEnum = 'invalid_status';
+    void status;
+  });
+
+  test('wrong array element type rejected', () => {
+    const badInsert: Insertable<User> = {
+      email: 'test@example.com',
+      username: 'test',
+      // @ts-expect-error - scores should be number[], not string[]
+      scores: ['a', 'b', 'c'],
+    };
+    void badInsert;
+  });
+
+  test('wrong join column rejected', () => {
+    db.selectFrom('users')
+      // @ts-expect-error - 'posts.nonexistent' is not a valid column
+      .innerJoin('posts', 'posts.nonexistent', 'users.id');
+  });
+
+  test('Generated column cannot be required in insert', () => {
+    const validInsert: Insertable<User> = {
+      email: 'test@example.com',
+      username: 'test',
+      id: 1, // id is Generated<number>, so this is optional - no error
+    };
+    void validInsert;
+  });
+});

--- a/test/fixtures/generated-types-camel.ts
+++ b/test/fixtures/generated-types-camel.ts
@@ -1,0 +1,82 @@
+import type { ColumnType } from 'kysely';
+
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
+
+export type StatusEnum = 'pending' | 'approved' | 'rejected';
+
+export interface Comment {
+  id: Generated<number>;
+  postId: number;
+  userId: number;
+  content: string;
+  status: StatusEnum;
+  createdAt: ColumnType<Date, Date | string, Date | string>;
+}
+
+export interface Measurement {
+  id: Generated<number>;
+  measureDate: ColumnType<Date, Date | string, Date | string>;
+  value: ColumnType<string, number | string, number | string>;
+  sensorId: number;
+}
+
+export interface Measurements2024Q1 {
+  id: Generated<number>;
+  measureDate: ColumnType<Date, Date | string, Date | string>;
+  value: ColumnType<string, number | string, number | string>;
+  sensorId: number;
+}
+
+export interface Measurements2024Q2 {
+  id: Generated<number>;
+  measureDate: ColumnType<Date, Date | string, Date | string>;
+  value: ColumnType<string, number | string, number | string>;
+  sensorId: number;
+}
+
+export interface Post {
+  id: Generated<number>;
+  userId: number;
+  title: string;
+  content: string | null;
+  publishedAt: ColumnType<Date, Date | string, Date | string> | null;
+  viewCount: number;
+}
+
+export interface User {
+  id: Generated<number>;
+  email: string;
+  username: string;
+  createdAt: ColumnType<Date, Date | string, Date | string>;
+  updatedAt: ColumnType<Date, Date | string, Date | string> | null;
+  isActive: boolean;
+  metadata: unknown | null;
+  tags: string[] | null;
+  scores: number[] | null;
+}
+
+export interface UserStat {
+  id: number | null;
+  username: string | null;
+  postCount: ColumnType<string, string | number | bigint, string | number | bigint> | null;
+  commentCount: ColumnType<string, string | number | bigint, string | number | bigint> | null;
+}
+
+export interface UserTagsView {
+  id: number | null;
+  username: string | null;
+  tags: string[] | null;
+}
+
+export interface DB {
+  comments: Comment;
+  measurements: Measurement;
+  measurements2024Q1: Measurements2024Q1;
+  measurements2024Q2: Measurements2024Q2;
+  posts: Post;
+  users: User;
+  userStats: UserStat;
+  userTagsView: UserTagsView;
+}

--- a/test/fixtures/generated-types.ts
+++ b/test/fixtures/generated-types.ts
@@ -1,0 +1,82 @@
+import type { ColumnType } from 'kysely';
+
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
+
+export type StatusEnum = 'pending' | 'approved' | 'rejected';
+
+export interface Comment {
+  id: Generated<number>;
+  post_id: number;
+  user_id: number;
+  content: string;
+  status: StatusEnum;
+  created_at: ColumnType<Date, Date | string, Date | string>;
+}
+
+export interface Measurement {
+  id: Generated<number>;
+  measure_date: ColumnType<Date, Date | string, Date | string>;
+  value: ColumnType<string, number | string, number | string>;
+  sensor_id: number;
+}
+
+export interface Measurements2024Q1 {
+  id: Generated<number>;
+  measure_date: ColumnType<Date, Date | string, Date | string>;
+  value: ColumnType<string, number | string, number | string>;
+  sensor_id: number;
+}
+
+export interface Measurements2024Q2 {
+  id: Generated<number>;
+  measure_date: ColumnType<Date, Date | string, Date | string>;
+  value: ColumnType<string, number | string, number | string>;
+  sensor_id: number;
+}
+
+export interface Post {
+  id: Generated<number>;
+  user_id: number;
+  title: string;
+  content: string | null;
+  published_at: ColumnType<Date, Date | string, Date | string> | null;
+  view_count: number;
+}
+
+export interface User {
+  id: Generated<number>;
+  email: string;
+  username: string;
+  created_at: ColumnType<Date, Date | string, Date | string>;
+  updated_at: ColumnType<Date, Date | string, Date | string> | null;
+  is_active: boolean;
+  metadata: unknown | null;
+  tags: string[] | null;
+  scores: number[] | null;
+}
+
+export interface UserStat {
+  id: number | null;
+  username: string | null;
+  post_count: ColumnType<string, string | number | bigint, string | number | bigint> | null;
+  comment_count: ColumnType<string, string | number | bigint, string | number | bigint> | null;
+}
+
+export interface UserTagsView {
+  id: number | null;
+  username: string | null;
+  tags: string[] | null;
+}
+
+export interface DB {
+  comments: Comment;
+  measurements: Measurement;
+  measurements_2024_q1: Measurements2024Q1;
+  measurements_2024_q2: Measurements2024Q2;
+  posts: Post;
+  users: User;
+  user_stats: UserStat;
+  user_tags_view: UserTagsView;
+}


### PR DESCRIPTION
## Summary

- Add E2E tests that generate types, spin up Kysely, and run real queries
- Sync tests verify generated fixture files match current tool output (CI fails if out of sync)
- Query tests cover SELECT, INSERT, UPDATE, JOIN, and materialized views
- Type error tests verify TypeScript catches invalid code at compile time

## Test structure

```
test/e2e/
  sync.test.ts        # 2 tests - verify fixtures match tool output
  queries.test.ts     # 15 tests - runtime query verification
  type-errors.test.ts # 9 tests - compile-time type checks
```

## New scripts

- `bun run types:generate` - regenerate both fixture files

## Test plan

- [x] All 141 tests pass
- [x] Sync tests fail if types are modified without regenerating fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)