### PR TITLE
feat: map interval to proper IPostgresInterval type

### DIFF
--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -80,6 +80,21 @@ export function transformDatabase(metadata: DatabaseMetadata, options?: Transfor
     exported: true,
   });
 
+  declarations.push({
+    kind: 'interface',
+    name: 'IPostgresInterval',
+    properties: [
+      { name: 'years', type: { kind: 'primitive', value: 'number' }, optional: true },
+      { name: 'months', type: { kind: 'primitive', value: 'number' }, optional: true },
+      { name: 'days', type: { kind: 'primitive', value: 'number' }, optional: true },
+      { name: 'hours', type: { kind: 'primitive', value: 'number' }, optional: true },
+      { name: 'minutes', type: { kind: 'primitive', value: 'number' }, optional: true },
+      { name: 'seconds', type: { kind: 'primitive', value: 'number' }, optional: true },
+      { name: 'milliseconds', type: { kind: 'primitive', value: 'number' }, optional: true },
+    ],
+    exported: true,
+  });
+
   for (const enumMetadata of metadata.enums) {
     declarations.push(transformEnum(enumMetadata));
   }

--- a/src/transform/type-mapper.ts
+++ b/src/transform/type-mapper.ts
@@ -144,8 +144,27 @@ export function mapPostgresType(
 
     case 'time':
     case 'timetz':
-    case 'interval':
       baseType = { kind: 'primitive', value: 'string' };
+      break;
+
+    case 'interval':
+      baseType = createColumnType(
+        { kind: 'reference', name: 'IPostgresInterval' },
+        {
+          kind: 'union',
+          types: [
+            { kind: 'reference', name: 'IPostgresInterval' },
+            { kind: 'primitive', value: 'string' },
+          ],
+        },
+        {
+          kind: 'union',
+          types: [
+            { kind: 'reference', name: 'IPostgresInterval' },
+            { kind: 'primitive', value: 'string' },
+          ],
+        }
+      );
       break;
 
     case 'money':

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -15,6 +15,16 @@ export type JsonObject = { [key: string]: JsonValue };
 
 export type JsonValue = JsonPrimitive | JsonObject | JsonArray;
 
+export interface IPostgresInterval {
+  years?: number;
+  months?: number;
+  days?: number;
+  hours?: number;
+  minutes?: number;
+  seconds?: number;
+  milliseconds?: number;
+}
+
 export type StatusEnum = 'pending' | 'approved' | 'rejected';
 
 export interface Comment {


### PR DESCRIPTION
## Summary

- Maps `interval` PostgreSQL type to `ColumnType<IPostgresInterval, IPostgresInterval | string, IPostgresInterval | string>`
- Adds `IPostgresInterval` interface matching the `pg` driver's output format

## Changes

- `src/transform/type-mapper.ts`: Return ColumnType with IPostgresInterval for interval
- `src/transform/index.ts`: Add IPostgresInterval interface declaration
- Tests updated with new interval type behavior

## Example output

```typescript
export interface IPostgresInterval {
  years?: number;
  months?: number;
  days?: number;
  hours?: number;
  minutes?: number;
  seconds?: number;
  milliseconds?: number;
}

export interface Task {
  duration: ColumnType<IPostgresInterval, IPostgresInterval | string, IPostgresInterval | string>;
  timeout: ColumnType<IPostgresInterval, IPostgresInterval | string, IPostgresInterval | string> | null;
}
```

## Test plan

- [x] Unit tests for interval type mapping
- [x] Unit tests for IPostgresInterval interface presence
- [x] Unit tests for nullable interval columns
- [x] Integration test snapshot updated
- [x] All 145 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)