### PR TITLE
feat: add SQLite dialect support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Generate TypeScript types from your database for [Kysely](https://kysely.dev/).
 
-Supports PostgreSQL and MySQL.
+Supports PostgreSQL, MySQL, and SQLite.
 
 ## Install
 
@@ -12,6 +12,9 @@ npm install kysely-gen kysely pg
 
 # MySQL
 npm install kysely-gen kysely mysql2
+
+# SQLite
+npm install kysely-gen kysely better-sqlite3
 ```
 
 ## Usage
@@ -23,6 +26,9 @@ DATABASE_URL=postgres://user:pass@localhost:5432/db npx kysely-gen
 # MySQL (auto-detected from URL)
 DATABASE_URL=mysql://user:pass@localhost:3306/db npx kysely-gen
 
+# SQLite (auto-detected from file extension)
+npx kysely-gen --url ./database.db
+
 # Explicit dialect
 npx kysely-gen --dialect mysql --url mysql://user:pass@localhost:3306/db
 ```
@@ -31,7 +37,7 @@ npx kysely-gen --dialect mysql --url mysql://user:pass@localhost:3306/db
 
 | Option | Description |
 |--------|-------------|
-| `--dialect <name>` | Database dialect: `postgres` or `mysql` (auto-detected from URL) |
+| `--dialect <name>` | Database dialect: `postgres`, `mysql`, or `sqlite` (auto-detected) |
 | `--out <path>` | Output file (default: `./db.d.ts`) |
 | `--schema <name>` | Schema to introspect (repeatable) |
 | `--url <string>` | Database URL (overrides `DATABASE_URL`) |
@@ -85,6 +91,12 @@ export interface DB {
 - Geometry types (Point, LineString, Polygon)
 - `tinyint(1)` mapped to boolean
 
+### SQLite
+- `Generated<T>` for INTEGER PRIMARY KEY (auto-increment)
+- Views
+- JSON columns mapped to `JsonValue`
+- Simple type affinity mapping (no ColumnType wrappers)
+
 ## Type Mappings
 
 ### PostgreSQL
@@ -108,6 +120,17 @@ export interface DB {
 | `json` | `JsonValue` |
 | `point` | `Point` |
 | `enum('a','b')` | `'a' \| 'b'` |
+
+### SQLite
+| SQLite | TypeScript |
+|--------|------------|
+| `INTEGER`, `INT`, `BIGINT` | `number` |
+| `REAL`, `DOUBLE`, `FLOAT` | `number` |
+| `TEXT`, `VARCHAR`, `CHAR` | `string` |
+| `BLOB` | `Buffer` |
+| `DATE`, `DATETIME`, `TIMESTAMP` | `string` |
+| `JSON` | `JsonValue` |
+| `BOOLEAN` | `number` (0/1) |
 
 ## License
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,9 +12,11 @@
         "pg": "^8.16.3",
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/bun": "^1.1.12",
         "@types/micromatch": "^4.0.10",
         "@types/pg": "^8.11.10",
+        "better-sqlite3": "^12.5.0",
         "mysql2": "^3.11.0",
         "typescript": "^5.6.3",
       },
@@ -30,6 +32,8 @@
     },
   },
   "packages": {
+    "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
+
     "@types/braces": ["@types/braces@3.0.5", "", {}, "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w=="],
 
     "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
@@ -44,11 +48,23 @@
 
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "better-sqlite3": ["better-sqlite3@12.5.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
@@ -56,15 +72,37 @@
 
     "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "generate-function": ["generate-function@2.3.1", "", { "dependencies": { "is-property": "^1.0.2" } }, "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
+
     "iconv-lite": ["iconv-lite@0.7.1", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
 
@@ -86,9 +124,21 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
+    "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
     "mysql2": ["mysql2@3.16.0", "", { "dependencies": { "aws-ssl-profiles": "^1.1.1", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.0", "long": "^5.2.1", "lru.min": "^1.0.0", "named-placeholders": "^1.1.3", "seq-queue": "^0.0.5", "sqlstring": "^2.3.2" } }, "sha512-AEGW7QLLSuSnjCS4pk3EIqOmogegmze9h8EyrndavUQnIUcfkVal/sK7QznE+a3bc6rzPbAiui9Jcb+96tPwYA=="],
 
     "named-placeholders": ["named-placeholders@1.1.6", "", { "dependencies": { "lru.min": "^1.1.0" } }, "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="],
+
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
+    "node-abi": ["node-abi@3.85.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
@@ -120,13 +170,29 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
+    "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "seq-queue": ["seq-queue@0.0.5", "", {}, "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
@@ -136,13 +202,27 @@
 
     "string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
 
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kysely-gen",
   "version": "0.3.0",
-  "description": "Database type generator for Kysely - Supports PostgreSQL and MySQL",
+  "description": "Database type generator for Kysely - Supports PostgreSQL, MySQL, and SQLite",
   "type": "module",
   "license": "MIT",
   "author": "kysely-gen contributors",
@@ -18,6 +18,7 @@
     "postgres",
     "postgresql",
     "mysql",
+    "sqlite",
     "typescript",
     "codegen",
     "typegen",
@@ -61,22 +62,28 @@
     "pg": "^8.16.3"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/bun": "^1.1.12",
     "@types/micromatch": "^4.0.10",
     "@types/pg": "^8.11.10",
+    "better-sqlite3": "^12.5.0",
     "mysql2": "^3.11.0",
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
     "kysely": ">=0.27.0 <1.0.0",
     "pg": ">=8.8.0 <9.0.0",
-    "mysql2": ">=3.0.0 <4.0.0"
+    "mysql2": ">=3.0.0 <4.0.0",
+    "better-sqlite3": ">=9.0.0 <13.0.0"
   },
   "peerDependenciesMeta": {
     "pg": {
       "optional": true
     },
     "mysql2": {
+      "optional": true
+    },
+    "better-sqlite3": {
       "optional": true
     }
   }

--- a/src/dialects/index.ts
+++ b/src/dialects/index.ts
@@ -1,6 +1,7 @@
 import type { Dialect, DialectName } from './types';
 import { PostgresDialect } from './postgres';
 import { MysqlDialect } from './mysql';
+import { SqliteDialect } from './sqlite';
 
 export function getDialect(name: DialectName): Dialect {
   switch (name) {
@@ -8,12 +9,24 @@ export function getDialect(name: DialectName): Dialect {
       return new PostgresDialect();
     case 'mysql':
       return new MysqlDialect();
+    case 'sqlite':
+      return new SqliteDialect();
     default:
       throw new Error(`Unknown dialect: ${name}`);
   }
 }
 
 export function detectDialect(connectionString: string): DialectName | null {
+  if (
+    connectionString === ':memory:' ||
+    connectionString.endsWith('.db') ||
+    connectionString.endsWith('.sqlite') ||
+    connectionString.endsWith('.sqlite3') ||
+    connectionString.startsWith('file:')
+  ) {
+    return 'sqlite';
+  }
+
   try {
     const url = new URL(connectionString);
     const protocol = url.protocol.replace(':', '');
@@ -35,4 +48,5 @@ export function detectDialect(connectionString: string): DialectName | null {
 
 export { PostgresDialect } from './postgres';
 export { MysqlDialect } from './mysql';
+export { SqliteDialect } from './sqlite';
 export type { Dialect, DialectName, IntrospectOptions, MapTypeOptions } from './types';

--- a/src/dialects/sqlite/index.ts
+++ b/src/dialects/sqlite/index.ts
@@ -1,0 +1,26 @@
+import { SqliteDialect as KyselySqliteDialect } from 'kysely';
+import type { Kysely, Dialect as KyselyDialect } from 'kysely';
+import type { Dialect, IntrospectOptions, MapTypeOptions } from '@/dialects/types';
+import type { DatabaseMetadata } from '@/introspect/types';
+import type { TypeNode } from '@/ast/nodes';
+import { introspectSqlite } from './introspect';
+import { mapSqliteType } from './type-mapper';
+
+export class SqliteDialect implements Dialect {
+  readonly name = 'sqlite' as const;
+
+  async createKyselyDialect(connectionString: string): Promise<KyselyDialect> {
+    const Database = await import('better-sqlite3').then((m) => m.default);
+    return new KyselySqliteDialect({
+      database: new Database(connectionString),
+    });
+  }
+
+  async introspect(db: Kysely<any>, options: IntrospectOptions): Promise<DatabaseMetadata> {
+    return introspectSqlite(db, options);
+  }
+
+  mapType(dataType: string, options: MapTypeOptions): TypeNode {
+    return mapSqliteType(dataType, options);
+  }
+}

--- a/src/dialects/sqlite/introspect.ts
+++ b/src/dialects/sqlite/introspect.ts
@@ -1,0 +1,111 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+import type { ColumnMetadata, DatabaseMetadata, TableMetadata } from '@/introspect/types';
+import type { IntrospectOptions } from '@/dialects/types';
+
+type RawTableInfo = {
+  name: string;
+  type: string;
+};
+
+type RawColumnInfo = {
+  cid: number;
+  name: string;
+  type: string;
+  notnull: number;
+  dflt_value: string | null;
+  pk: number;
+};
+
+export async function introspectSqlite(
+  db: Kysely<any>,
+  _options: IntrospectOptions,
+): Promise<DatabaseMetadata> {
+  const [baseTables, views] = await Promise.all([
+    introspectTables(db),
+    introspectViews(db),
+  ]);
+
+  return {
+    tables: [...baseTables, ...views],
+    enums: [],
+  };
+}
+
+async function introspectTables(db: Kysely<any>): Promise<TableMetadata[]> {
+  const rawTables = await sql<RawTableInfo>`
+    SELECT name, type FROM sqlite_master
+    WHERE type = 'table'
+      AND name NOT LIKE 'sqlite_%'
+    ORDER BY name
+  `.execute(db);
+
+  const tables: TableMetadata[] = [];
+
+  for (const rawTable of rawTables.rows) {
+    const columns = await introspectColumns(db, rawTable.name, false);
+    tables.push({
+      schema: 'main',
+      name: rawTable.name,
+      columns,
+    });
+  }
+
+  return tables;
+}
+
+async function introspectViews(db: Kysely<any>): Promise<TableMetadata[]> {
+  const rawViews = await sql<RawTableInfo>`
+    SELECT name, type FROM sqlite_master
+    WHERE type = 'view'
+    ORDER BY name
+  `.execute(db);
+
+  const tables: TableMetadata[] = [];
+
+  for (const rawView of rawViews.rows) {
+    const columns = await introspectColumns(db, rawView.name, true);
+    tables.push({
+      schema: 'main',
+      name: rawView.name,
+      columns,
+      isView: true,
+    });
+  }
+
+  return tables;
+}
+
+async function introspectColumns(
+  db: Kysely<any>,
+  tableName: string,
+  isView: boolean,
+): Promise<ColumnMetadata[]> {
+  const rawColumns = await sql<RawColumnInfo>`
+    PRAGMA table_info(${sql.raw(`'${tableName}'`)})
+  `.execute(db);
+
+  return rawColumns.rows.map((col) => {
+    const isIntegerPk = col.pk === 1 && col.type.toUpperCase() === 'INTEGER';
+    const isAutoIncrement = !isView && isIntegerPk;
+
+    return {
+      name: col.name,
+      dataType: normalizeDataType(col.type),
+      dataTypeSchema: 'main',
+      isNullable: col.notnull === 0 && col.pk === 0,
+      isAutoIncrement,
+      hasDefaultValue: col.dflt_value !== null || isAutoIncrement,
+    };
+  });
+}
+
+function normalizeDataType(type: string): string {
+  const lowerType = type.toLowerCase();
+
+  if (lowerType === '' || lowerType === 'blob') {
+    return 'blob';
+  }
+
+  return lowerType;
+}

--- a/src/dialects/sqlite/type-mapper.ts
+++ b/src/dialects/sqlite/type-mapper.ts
@@ -1,0 +1,71 @@
+import type { TypeNode } from '@/ast/nodes';
+import type { MapTypeOptions } from '@/dialects/types';
+
+export function mapSqliteType(dataType: string, options: MapTypeOptions): TypeNode {
+  const { isNullable, unknownTypes } = options;
+
+  let baseType: TypeNode;
+  const lowerType = dataType.toLowerCase();
+
+  switch (lowerType) {
+    case 'integer':
+    case 'int':
+    case 'tinyint':
+    case 'smallint':
+    case 'mediumint':
+    case 'bigint':
+      baseType = { kind: 'primitive', value: 'number' };
+      break;
+
+    case 'real':
+    case 'double':
+    case 'float':
+      baseType = { kind: 'primitive', value: 'number' };
+      break;
+
+    case 'numeric':
+    case 'decimal':
+      baseType = { kind: 'primitive', value: 'number' };
+      break;
+
+    case 'text':
+    case 'varchar':
+    case 'char':
+    case 'clob':
+      baseType = { kind: 'primitive', value: 'string' };
+      break;
+
+    case 'blob':
+      baseType = { kind: 'primitive', value: 'Buffer' };
+      break;
+
+    case 'date':
+    case 'datetime':
+    case 'timestamp':
+      baseType = { kind: 'primitive', value: 'string' };
+      break;
+
+    case 'boolean':
+      baseType = { kind: 'primitive', value: 'number' };
+      break;
+
+    case 'json':
+      baseType = { kind: 'reference', name: 'JsonValue' };
+      break;
+
+    default:
+      if (unknownTypes) {
+        unknownTypes.add(dataType);
+      }
+      baseType = { kind: 'primitive', value: 'unknown' };
+  }
+
+  if (isNullable) {
+    return {
+      kind: 'union',
+      types: [baseType, { kind: 'primitive', value: 'null' }],
+    };
+  }
+
+  return baseType;
+}

--- a/src/dialects/types.ts
+++ b/src/dialects/types.ts
@@ -2,7 +2,7 @@ import type { Kysely, Dialect as KyselyDialect } from 'kysely';
 import type { TypeNode } from '@/ast/nodes';
 import type { DatabaseMetadata } from '@/introspect/types';
 
-export type DialectName = 'postgres' | 'mysql';
+export type DialectName = 'postgres' | 'mysql' | 'sqlite';
 
 export type IntrospectOptions = {
   schemas: string[];

--- a/test/dialects/sqlite/type-mapper.test.ts
+++ b/test/dialects/sqlite/type-mapper.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+import { mapSqliteType } from '@/dialects/sqlite/type-mapper';
+
+describe('SQLite Type Mapper', () => {
+  describe('integer types', () => {
+    test('should map integer types to number', () => {
+      expect(mapSqliteType('integer', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapSqliteType('int', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapSqliteType('tinyint', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapSqliteType('smallint', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapSqliteType('mediumint', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapSqliteType('bigint', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+    });
+  });
+
+  describe('real types', () => {
+    test('should map real/double/float to number', () => {
+      expect(mapSqliteType('real', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapSqliteType('double', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapSqliteType('float', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+    });
+  });
+
+  describe('numeric types', () => {
+    test('should map numeric/decimal to number', () => {
+      expect(mapSqliteType('numeric', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapSqliteType('decimal', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+    });
+  });
+
+  describe('text types', () => {
+    test('should map text types to string', () => {
+      expect(mapSqliteType('text', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+      expect(mapSqliteType('varchar', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+      expect(mapSqliteType('char', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+      expect(mapSqliteType('clob', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+    });
+  });
+
+  describe('blob type', () => {
+    test('should map blob to Buffer', () => {
+      expect(mapSqliteType('blob', { isNullable: false })).toEqual({ kind: 'primitive', value: 'Buffer' });
+    });
+  });
+
+  describe('date types', () => {
+    test('should map date types to string', () => {
+      expect(mapSqliteType('date', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+      expect(mapSqliteType('datetime', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+      expect(mapSqliteType('timestamp', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+    });
+  });
+
+  describe('boolean type', () => {
+    test('should map boolean to number (SQLite stores as 0/1)', () => {
+      expect(mapSqliteType('boolean', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+    });
+  });
+
+  describe('json type', () => {
+    test('should map json to JsonValue reference', () => {
+      expect(mapSqliteType('json', { isNullable: false })).toEqual({ kind: 'reference', name: 'JsonValue' });
+    });
+  });
+
+  describe('nullable types', () => {
+    test('should wrap nullable types in union with null', () => {
+      const result = mapSqliteType('integer', { isNullable: true });
+      expect(result).toEqual({
+        kind: 'union',
+        types: [
+          { kind: 'primitive', value: 'number' },
+          { kind: 'primitive', value: 'null' },
+        ],
+      });
+    });
+
+    test('should wrap complex types in union with null', () => {
+      const result = mapSqliteType('json', { isNullable: true });
+      expect(result).toEqual({
+        kind: 'union',
+        types: [
+          { kind: 'reference', name: 'JsonValue' },
+          { kind: 'primitive', value: 'null' },
+        ],
+      });
+    });
+  });
+
+  describe('unknown types', () => {
+    test('should map unknown types to unknown', () => {
+      expect(mapSqliteType('custom_type', { isNullable: false })).toEqual({ kind: 'primitive', value: 'unknown' });
+    });
+
+    test('should track unknown types', () => {
+      const unknownTypes = new Set<string>();
+      mapSqliteType('my_custom_type', { isNullable: false, unknownTypes });
+      expect(unknownTypes.has('my_custom_type')).toBe(true);
+    });
+  });
+
+  describe('case insensitivity', () => {
+    test('should handle uppercase type names', () => {
+      expect(mapSqliteType('INTEGER', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapSqliteType('TEXT', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+      expect(mapSqliteType('BLOB', { isNullable: false })).toEqual({ kind: 'primitive', value: 'Buffer' });
+    });
+  });
+});

--- a/test/fixtures/sqlite-init.sql
+++ b/test/fixtures/sqlite-init.sql
@@ -1,0 +1,69 @@
+-- Test database schema for SQLite
+
+-- Users table
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  username TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT,
+  is_active INTEGER NOT NULL DEFAULT 1,
+  metadata JSON,
+  age INTEGER,
+  balance REAL
+);
+
+-- Posts table
+CREATE TABLE posts (
+  id INTEGER PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  content TEXT,
+  published_at TEXT,
+  view_count INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'draft' CHECK(status IN ('draft', 'published', 'archived'))
+);
+
+-- Comments table
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY,
+  post_id INTEGER NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  content TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'approved', 'rejected')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Table with BLOB type
+CREATE TABLE files (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  content BLOB,
+  checksum BLOB
+);
+
+-- Table with various numeric types
+CREATE TABLE metrics (
+  id INTEGER PRIMARY KEY,
+  int_val INTEGER,
+  real_val REAL,
+  numeric_val NUMERIC,
+  text_val TEXT,
+  blob_val BLOB
+);
+
+-- Create a view
+CREATE VIEW active_users AS
+SELECT id, email, username, created_at
+FROM users
+WHERE is_active = 1;
+
+-- Create view with join
+CREATE VIEW user_posts AS
+SELECT
+  u.id AS user_id,
+  u.username,
+  p.id AS post_id,
+  p.title
+FROM users u
+JOIN posts p ON u.id = p.user_id;

--- a/test/introspect/sqlite.test.ts
+++ b/test/introspect/sqlite.test.ts
@@ -1,0 +1,221 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { Kysely, SqliteDialect } from 'kysely';
+import { Database } from 'bun:sqlite';
+import { readFileSync } from 'fs';
+import { introspectSqlite } from '@/dialects/sqlite/introspect';
+import { createBunSqliteDatabase } from '../utils/bun-sqlite';
+
+describe('SQLite Introspector', () => {
+  let db: Kysely<any>;
+  let sqliteDb: Database;
+
+  beforeAll(async () => {
+    sqliteDb = new Database(':memory:');
+    db = new Kysely({
+      dialect: new SqliteDialect({ database: createBunSqliteDatabase(sqliteDb) }),
+    });
+
+    const initSql = readFileSync('test/fixtures/sqlite-init.sql', 'utf8');
+    sqliteDb.exec(initSql);
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  test('should introspect tables from database', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    expect(metadata.tables.length).toBeGreaterThan(0);
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    expect(users).toBeDefined();
+    expect(users?.schema).toBe('main');
+  });
+
+  test('should introspect columns with correct types', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    expect(users).toBeDefined();
+
+    const idColumn = users?.columns.find((c) => c.name === 'id');
+    expect(idColumn).toBeDefined();
+    expect(idColumn?.dataType).toBe('integer');
+    expect(idColumn?.isNullable).toBe(false);
+    expect(idColumn?.isAutoIncrement).toBe(true);
+
+    const emailColumn = users?.columns.find((c) => c.name === 'email');
+    expect(emailColumn).toBeDefined();
+    expect(emailColumn?.dataType).toBe('text');
+    expect(emailColumn?.isNullable).toBe(false);
+  });
+
+  test('should detect INTEGER PRIMARY KEY as auto-increment', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    const idColumn = users?.columns.find((c) => c.name === 'id');
+
+    expect(idColumn?.isAutoIncrement).toBe(true);
+    expect(idColumn?.hasDefaultValue).toBe(true);
+  });
+
+  test('should identify nullable columns', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    const updatedAtColumn = users?.columns.find((c) => c.name === 'updated_at');
+
+    expect(updatedAtColumn).toBeDefined();
+    expect(updatedAtColumn?.isNullable).toBe(true);
+  });
+
+  test('should have empty enums (SQLite has no native enum)', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+    expect(metadata.enums).toEqual([]);
+  });
+
+  test('should introspect BLOB columns', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const files = metadata.tables.find((t) => t.name === 'files');
+    expect(files).toBeDefined();
+
+    const contentColumn = files?.columns.find((c) => c.name === 'content');
+    expect(contentColumn?.dataType).toBe('blob');
+    expect(contentColumn?.isNullable).toBe(true);
+
+    const checksumColumn = files?.columns.find((c) => c.name === 'checksum');
+    expect(checksumColumn?.dataType).toBe('blob');
+  });
+
+  test('should introspect REAL columns', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    const balanceColumn = users?.columns.find((c) => c.name === 'balance');
+
+    expect(balanceColumn).toBeDefined();
+    expect(balanceColumn?.dataType).toBe('real');
+  });
+
+  test('should introspect views', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const activeUsers = metadata.tables.find((t) => t.name === 'active_users');
+    expect(activeUsers).toBeDefined();
+    expect(activeUsers?.isView).toBe(true);
+    expect(activeUsers?.schema).toBe('main');
+
+    const columns = activeUsers?.columns ?? [];
+    expect(columns.length).toBe(4);
+
+    const idColumn = columns.find((c) => c.name === 'id');
+    expect(idColumn).toBeDefined();
+  });
+
+  test('should introspect columns with default values', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    const isActiveColumn = users?.columns.find((c) => c.name === 'is_active');
+
+    expect(isActiveColumn).toBeDefined();
+    expect(isActiveColumn?.hasDefaultValue).toBe(true);
+  });
+
+  test('should introspect various numeric types', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const metrics = metadata.tables.find((t) => t.name === 'metrics');
+    expect(metrics).toBeDefined();
+
+    const intColumn = metrics?.columns.find((c) => c.name === 'int_val');
+    expect(intColumn?.dataType).toBe('integer');
+
+    const realColumn = metrics?.columns.find((c) => c.name === 'real_val');
+    expect(realColumn?.dataType).toBe('real');
+
+    const numericColumn = metrics?.columns.find((c) => c.name === 'numeric_val');
+    expect(numericColumn?.dataType).toBe('numeric');
+  });
+
+  test('should introspect all test tables', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const tableNames = metadata.tables
+      .filter((t) => !t.isView)
+      .map((t) => t.name)
+      .sort();
+
+    expect(tableNames).toContain('users');
+    expect(tableNames).toContain('posts');
+    expect(tableNames).toContain('comments');
+    expect(tableNames).toContain('files');
+    expect(tableNames).toContain('metrics');
+  });
+
+  test('should introspect JSON columns', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    const metadataColumn = users?.columns.find((c) => c.name === 'metadata');
+
+    expect(metadataColumn).toBeDefined();
+    expect(metadataColumn?.dataType).toBe('json');
+    expect(metadataColumn?.isNullable).toBe(true);
+  });
+
+  test('should introspect view with join', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const userPosts = metadata.tables.find((t) => t.name === 'user_posts');
+    expect(userPosts).toBeDefined();
+    expect(userPosts?.isView).toBe(true);
+
+    const columns = userPosts?.columns ?? [];
+    expect(columns.length).toBe(4);
+
+    const columnNames = columns.map((c) => c.name);
+    expect(columnNames).toContain('user_id');
+    expect(columnNames).toContain('username');
+    expect(columnNames).toContain('post_id');
+    expect(columnNames).toContain('title');
+  });
+
+  test('should detect NOT NULL constraints', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const posts = metadata.tables.find((t) => t.name === 'posts');
+    expect(posts).toBeDefined();
+
+    const titleColumn = posts?.columns.find((c) => c.name === 'title');
+    expect(titleColumn?.isNullable).toBe(false);
+
+    const contentColumn = posts?.columns.find((c) => c.name === 'content');
+    expect(contentColumn?.isNullable).toBe(true);
+  });
+
+  test('should not mark view columns as auto-increment', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const activeUsers = metadata.tables.find((t) => t.name === 'active_users');
+    const idColumn = activeUsers?.columns.find((c) => c.name === 'id');
+
+    expect(idColumn).toBeDefined();
+    expect(idColumn?.isAutoIncrement).toBe(false);
+  });
+
+  test('should introspect foreign key columns', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const posts = metadata.tables.find((t) => t.name === 'posts');
+    const userIdColumn = posts?.columns.find((c) => c.name === 'user_id');
+
+    expect(userIdColumn).toBeDefined();
+    expect(userIdColumn?.dataType).toBe('integer');
+    expect(userIdColumn?.isNullable).toBe(false);
+    expect(userIdColumn?.isAutoIncrement).toBe(false);
+  });
+});

--- a/test/utils/bun-sqlite.ts
+++ b/test/utils/bun-sqlite.ts
@@ -1,0 +1,29 @@
+import { Database } from 'bun:sqlite';
+
+export function createBunSqliteDatabase(db: Database) {
+  return {
+    close: () => db.close(),
+    prepare: (query: string) => {
+      const stmt = db.prepare(query);
+      const isReader =
+        query.trim().toLowerCase().startsWith('select') ||
+        query.trim().toLowerCase().startsWith('pragma');
+      return {
+        reader: isReader,
+        all: (params: unknown[]) => stmt.all(...params),
+        run: (params: unknown[]) => {
+          const result = stmt.run(...params);
+          return {
+            changes: result.changes,
+            lastInsertRowid: result.lastInsertRowid,
+          };
+        },
+        *iterate(params: unknown[]) {
+          for (const row of stmt.iterate(...params)) {
+            yield row;
+          }
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add SQLite as third supported dialect alongside PostgreSQL and MySQL
- Introspect tables, views, and columns via `sqlite_master` and `PRAGMA table_info`
- Simple type affinity mapping (no ColumnType wrappers needed for SQLite)
- Auto-detect SQLite from file extensions (.db, .sqlite, .sqlite3) or `:memory:`

## Changes
- New `src/dialects/sqlite/` with introspect.ts, type-mapper.ts, index.ts
- Update CLI to support `--dialect sqlite` and auto-detection
- Add `better-sqlite3` as optional peer dependency
- 29 new tests for SQLite (16 introspection + 13 type mapper)
- Update README with SQLite documentation

## Type Mappings
| SQLite | TypeScript |
|--------|------------|
| INTEGER, INT, BIGINT | `number` |
| REAL, DOUBLE, FLOAT | `number` |
| TEXT, VARCHAR, CHAR | `string` |
| BLOB | `Buffer` |
| DATE, DATETIME, TIMESTAMP | `string` |
| JSON | `JsonValue` |

## Test plan
- [x] All 223 tests pass
- [x] SQLite introspection tests cover tables, views, columns, types
- [x] Type mapper tests cover all SQLite affinities

🤖 Generated with [Claude Code](https://claude.com/claude-code)