### PR TITLE
feat: add --print flag for stdout output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,7 @@ This makes auto-increment and default-value columns optional during insert opera
 - `--camel-case` - Convert column/table names to camelCase
 - `--include-pattern <pattern>` - Only include matching tables (glob)
 - `--exclude-pattern <pattern>` - Exclude matching tables (glob)
+- `--print` - Output to stdout instead of file (ignores `--out`)
 
 ## Publishing
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test';
+import { spawn } from 'bun';
+import { resolve } from 'node:path';
+import { unlink } from 'node:fs/promises';
+
+const TEST_DATABASE_URL = 'postgres://test_user:test_password@localhost:5433/test_db';
+const CLI_PATH = resolve(import.meta.dir, '../src/cli.ts');
+
+describe('CLI', () => {
+  describe('--print flag', () => {
+    test('should output TypeScript code to stdout', async () => {
+      const proc = spawn({
+        cmd: ['bun', CLI_PATH, '--print'],
+        env: { ...process.env, DATABASE_URL: TEST_DATABASE_URL },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+
+      const stdout = await new Response(proc.stdout).text();
+      await proc.exited;
+
+      expect(stdout).toContain("import type { ColumnType } from 'kysely'");
+      expect(stdout).toContain('export type Generated<T>');
+      expect(stdout).toContain('export interface User {');
+      expect(stdout).toContain('export interface DB {');
+    });
+
+    test('should send progress messages to stderr', async () => {
+      const proc = spawn({
+        cmd: ['bun', CLI_PATH, '--print'],
+        env: { ...process.env, DATABASE_URL: TEST_DATABASE_URL },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+
+      const stderr = await new Response(proc.stderr).text();
+      await proc.exited;
+
+      expect(stderr).toContain('kysely-gen');
+      expect(stderr).toContain('Connected to database');
+      expect(stderr).toContain('Types generated');
+    });
+
+    test('should not include output path in progress when --print is set', async () => {
+      const proc = spawn({
+        cmd: ['bun', CLI_PATH, '--print'],
+        env: { ...process.env, DATABASE_URL: TEST_DATABASE_URL },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+
+      const stderr = await new Response(proc.stderr).text();
+      await proc.exited;
+
+      expect(stderr).not.toContain('Output:');
+    });
+
+    test('should ignore --out when --print is set', async () => {
+      const testOutputPath = '/tmp/test-should-not-exist.d.ts';
+
+      try {
+        await unlink(testOutputPath);
+      } catch {
+        // file doesn't exist, that's fine
+      }
+
+      const proc = spawn({
+        cmd: ['bun', CLI_PATH, '--print', '--out', testOutputPath],
+        env: { ...process.env, DATABASE_URL: TEST_DATABASE_URL },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+
+      await proc.exited;
+
+      const fileExists = await Bun.file(testOutputPath).exists();
+      expect(fileExists).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `--print` flag that outputs generated types to stdout
- Progress/status messages go to stderr when `--print` is set
- `--out` flag is ignored when `--print` is used

## Usage
```bash
kysely-gen --print > custom-path.ts
kysely-gen --print | prettier --stdin-filepath db.ts
```

## Test plan
- [x] Added CLI tests for --print flag behavior
- [x] All 227 tests pass

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)