### PR TITLE
fix: handle enum name collisions across schemas

### DIFF
--- a/src/transform/enum.ts
+++ b/src/transform/enum.ts
@@ -2,17 +2,61 @@ import type { TypeAliasNode } from '@/ast/nodes';
 import type { EnumMetadata } from '@/introspect/types';
 import { toPascalCase } from '@/transform/utils';
 
-export function getEnumTypeName(enumMeta: EnumMetadata, defaultSchema = 'public'): string {
+function getEnumKey(enumMeta: EnumMetadata): string {
+  return `${enumMeta.schema}.${enumMeta.name}`;
+}
+
+function getBaseName(enumMeta: EnumMetadata, defaultSchema = 'public'): string {
   if (enumMeta.schema === defaultSchema) {
     return toPascalCase(enumMeta.name);
   }
   return toPascalCase(enumMeta.schema) + toPascalCase(enumMeta.name);
 }
 
-export function transformEnum(enumMetadata: EnumMetadata, defaultSchema = 'public'): TypeAliasNode {
+function getFullName(enumMeta: EnumMetadata): string {
+  return toPascalCase(enumMeta.schema) + toPascalCase(enumMeta.name);
+}
+
+export class EnumNameResolver {
+  private nameMap: Map<string, string>;
+
+  constructor(enums: EnumMetadata[], defaultSchema = 'public') {
+    this.nameMap = new Map();
+
+    const baseNames = new Map<string, EnumMetadata[]>();
+    for (const enumMeta of enums) {
+      const baseName = getBaseName(enumMeta, defaultSchema);
+      const existing = baseNames.get(baseName) ?? [];
+      existing.push(enumMeta);
+      baseNames.set(baseName, existing);
+    }
+
+    for (const [, enumsWithSameName] of baseNames) {
+      if (enumsWithSameName.length === 1) {
+        const enumMeta = enumsWithSameName[0];
+        this.nameMap.set(getEnumKey(enumMeta), getBaseName(enumMeta, defaultSchema));
+      } else {
+        for (const enumMeta of enumsWithSameName) {
+          this.nameMap.set(getEnumKey(enumMeta), getFullName(enumMeta));
+        }
+      }
+    }
+  }
+
+  getName(enumMeta: EnumMetadata): string {
+    return this.nameMap.get(getEnumKey(enumMeta))!;
+  }
+}
+
+export function getEnumTypeName(enumMeta: EnumMetadata, defaultSchema = 'public'): string {
+  return getBaseName(enumMeta, defaultSchema);
+}
+
+export function transformEnum(enumMetadata: EnumMetadata, resolver?: EnumNameResolver): TypeAliasNode {
+  const name = resolver ? resolver.getName(enumMetadata) : getEnumTypeName(enumMetadata);
   return {
     kind: 'typeAlias',
-    name: getEnumTypeName(enumMetadata, defaultSchema),
+    name,
     type: {
       kind: 'union',
       types: enumMetadata.values.map((value) => ({

--- a/src/transform/table.ts
+++ b/src/transform/table.ts
@@ -3,17 +3,18 @@ import type { ColumnMetadata, EnumMetadata, TableMetadata } from '@/introspect/t
 import { toCamelCase } from '@/utils/case-converter';
 import type { TransformOptions, TypeMapper } from '@/transform/types';
 import { toPascalCase, singularize } from '@/transform/utils';
-import { getEnumTypeName } from '@/transform/enum';
+import type { EnumNameResolver } from '@/transform/enum';
 
 export function transformTable(
   table: TableMetadata,
   enums: EnumMetadata[],
+  enumResolver: EnumNameResolver,
   mapType: TypeMapper,
   options?: TransformOptions,
   unknownTypes?: Set<string>
 ): InterfaceNode {
   const properties: PropertyNode[] = table.columns.map((column) =>
-    transformColumn(column, enums, mapType, options, unknownTypes)
+    transformColumn(column, enums, enumResolver, mapType, options, unknownTypes)
   );
 
   return {
@@ -27,6 +28,7 @@ export function transformTable(
 export function transformColumn(
   column: ColumnMetadata,
   enums: EnumMetadata[],
+  enumResolver: EnumNameResolver,
   mapType: TypeMapper,
   options?: TransformOptions,
   unknownTypes?: Set<string>
@@ -37,7 +39,7 @@ export function transformColumn(
 
   let type: TypeNode;
   if (matchingEnum) {
-    const enumTypeName = getEnumTypeName(matchingEnum);
+    const enumTypeName = enumResolver.getName(matchingEnum);
     type = { kind: 'reference', name: enumTypeName };
 
     if (column.isNullable) {


### PR DESCRIPTION
## Summary
- Add `EnumNameResolver` class to detect and resolve enum name collisions
- When two enums from different schemas would produce the same type name, prefix both with their schema name
- Example: `public.audit_status` and `audit.status` become `PublicAuditStatus` and `AuditStatus`

## Test plan
- [x] Added unit tests for collision detection
- [x] Added unit tests for collision-resolved references in column types
- [x] Added test to verify no prefix when no collision exists
- [x] All 230 tests pass

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)