### PR TITLE
feat: add ArrayType<T> helper for ColumnType arrays

### DIFF
--- a/src/dialects/postgres/type-mapper.ts
+++ b/src/dialects/postgres/type-mapper.ts
@@ -29,10 +29,16 @@ export function mapPostgresType(dataType: string, options: MapTypeOptions): Type
   if (isArray || dataType.endsWith('[]')) {
     const baseTypeName = dataType.endsWith('[]') ? dataType.slice(0, -2) : dataType;
     const elementType = mapPostgresType(baseTypeName, { isNullable: false, isArray: false, unknownTypes });
-    const arrayType: TypeNode = {
-      kind: 'array',
-      elementType,
-    };
+
+    const isSimple = elementType.kind === 'primitive' &&
+      ['boolean', 'number', 'string'].includes(elementType.value);
+
+    let arrayType: TypeNode;
+    if (isSimple) {
+      arrayType = { kind: 'array', elementType };
+    } else {
+      arrayType = { kind: 'generic', name: 'ArrayType', typeArguments: [elementType] };
+    }
 
     if (isNullable) {
       return {

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -47,6 +47,30 @@ export function transformDatabase(metadata: DatabaseMetadata, options?: Transfor
 
   declarations.push({
     kind: 'typeAlias',
+    name: 'ArrayType<T>',
+    type: {
+      kind: 'raw',
+      value: `ArrayTypeImpl<T> extends (infer U)[]
+  ? U[]
+  : ArrayTypeImpl<T>`,
+    },
+    exported: true,
+  });
+
+  declarations.push({
+    kind: 'typeAlias',
+    name: 'ArrayTypeImpl<T>',
+    type: {
+      kind: 'raw',
+      value: `T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S[], I[], U[]>
+  : T[]`,
+    },
+    exported: true,
+  });
+
+  declarations.push({
+    kind: 'typeAlias',
     name: 'JsonPrimitive',
     type: {
       kind: 'union',

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -7,6 +7,14 @@ export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
   ? ColumnType<S, I | undefined, U>
   : ColumnType<T, T | undefined, T>;
 
+export type ArrayType<T> = ArrayTypeImpl<T> extends (infer U)[]
+  ? U[]
+  : ArrayTypeImpl<T>;
+
+export type ArrayTypeImpl<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S[], I[], U[]>
+  : T[];
+
 export type JsonPrimitive = string | number | boolean | null;
 
 export type JsonArray = JsonValue[];


### PR DESCRIPTION
## Summary

- Adds `ArrayType<T>` and `ArrayTypeImpl<T>` type helpers
- Arrays of ColumnType now correctly preserve select/insert/update semantics
- Simple types (boolean, number, string) still use `T[]`
- Complex types (ColumnType, references) now use `ArrayType<T>`

**Before:** `timestamp[]` → `ColumnType<Date, Date | string, ...>[]`
**After:** `timestamp[]` → `ArrayType<ColumnType<Date, Date | string, ...>>`

## Test plan

- [x] All 234 tests pass
- [x] Verified type checking with `Insertable<User>` accepts `string[]` for timestamp arrays

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)