### PR TITLE
fix: filter out partition tables from generated types

### DIFF
--- a/src/transform/filter.ts
+++ b/src/transform/filter.ts
@@ -3,11 +3,13 @@ import type { TableMetadata } from '@/introspect/types';
 import type { TransformOptions } from '@/transform/types';
 
 export function filterTables(tables: TableMetadata[], options?: TransformOptions): TableMetadata[] {
+  const nonPartitionTables = tables.filter((t) => !t.isPartition);
+
   if (!options || (!options.includePattern && !options.excludePattern)) {
-    return tables;
+    return nonPartitionTables;
   }
 
-  return tables.filter((table) => {
+  return nonPartitionTables.filter((table) => {
     const tablePattern = `${table.schema}.${table.name}`;
 
     if (options.excludePattern && options.excludePattern.length > 0) {

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -51,20 +51,6 @@ export interface Measurement {
   sensor_id: number;
 }
 
-export interface Measurements2024Q1 {
-  id: Generated<number>;
-  measure_date: ColumnType<Date, Date | string, Date | string>;
-  value: ColumnType<string, number | string, number | string>;
-  sensor_id: number;
-}
-
-export interface Measurements2024Q2 {
-  id: Generated<number>;
-  measure_date: ColumnType<Date, Date | string, Date | string>;
-  value: ColumnType<string, number | string, number | string>;
-  sensor_id: number;
-}
-
 export interface Post {
   id: Generated<number>;
   user_id: number;
@@ -109,8 +95,6 @@ export interface UserTagsView {
 export interface DB {
   comments: Comment;
   measurements: Measurement;
-  measurements_2024_q1: Measurements2024Q1;
-  measurements_2024_q2: Measurements2024Q2;
   posts: Post;
   users: User;
   active_users: ActiveUser;

--- a/test/transform/filter.test.ts
+++ b/test/transform/filter.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import { filterTables } from '@/transform/filter';
+import type { TableMetadata } from '@/introspect/types';
+
+function createTable(name: string, opts?: { isPartition?: boolean; schema?: string }): TableMetadata {
+  return {
+    name,
+    schema: opts?.schema ?? 'public',
+    columns: [],
+    isPartition: opts?.isPartition,
+  };
+}
+
+describe('filterTables', () => {
+  test('should filter out partition tables', () => {
+    const tables = [
+      createTable('measurements'),
+      createTable('measurements_2024_q1', { isPartition: true }),
+      createTable('measurements_2024_q2', { isPartition: true }),
+      createTable('users'),
+    ];
+
+    const result = filterTables(tables);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.name)).toEqual(['measurements', 'users']);
+  });
+
+  test('should keep all tables when none are partitions', () => {
+    const tables = [createTable('users'), createTable('posts'), createTable('comments')];
+
+    const result = filterTables(tables);
+
+    expect(result).toHaveLength(3);
+  });
+
+  test('should apply pattern filtering after partition filtering', () => {
+    const tables = [
+      createTable('measurements'),
+      createTable('measurements_2024_q1', { isPartition: true }),
+      createTable('users'),
+      createTable('logs'),
+    ];
+
+    const result = filterTables(tables, { excludePattern: ['*.logs'] });
+
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.name)).toEqual(['measurements', 'users']);
+  });
+
+  test('should apply include pattern after partition filtering', () => {
+    const tables = [
+      createTable('measurements'),
+      createTable('measurements_2024_q1', { isPartition: true }),
+      createTable('users'),
+    ];
+
+    const result = filterTables(tables, { includePattern: ['*.users'] });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('users');
+  });
+});


### PR DESCRIPTION
## Summary
- Filter partition tables from generated types during transform
- Only parent tables appear in output, child partitions are excluded
- Adds `test/transform/filter.test.ts` with unit tests

Closes #15

## Test plan
- [x] Unit tests for partition filtering in `test/transform/filter.test.ts`
- [x] Integration test snapshot updated
- [x] All 238 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)