### PR TITLE
feat: add MSSQL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Generate TypeScript types from your database for [Kysely](https://kysely.dev/).
 
-Supports PostgreSQL, MySQL, and SQLite.
+Supports PostgreSQL, MySQL, SQLite, and MSSQL.
 
 ## Install
 
@@ -15,6 +15,9 @@ npm install kysely-gen kysely mysql2
 
 # SQLite
 npm install kysely-gen kysely better-sqlite3
+
+# MSSQL
+npm install kysely-gen kysely tedious tarn
 ```
 
 ## Usage
@@ -29,6 +32,10 @@ DATABASE_URL=mysql://user:pass@localhost:3306/db npx kysely-gen
 # SQLite (auto-detected from file extension)
 npx kysely-gen --url ./database.db
 
+# MSSQL (auto-detected from URL or connection string)
+npx kysely-gen --url "mssql://user:pass@localhost:1433/db"
+npx kysely-gen --url "Server=localhost;Database=db;User Id=user;Password=pass"
+
 # Explicit dialect
 npx kysely-gen --dialect mysql --url mysql://user:pass@localhost:3306/db
 ```
@@ -37,7 +44,7 @@ npx kysely-gen --dialect mysql --url mysql://user:pass@localhost:3306/db
 
 | Option | Description |
 |--------|-------------|
-| `--dialect <name>` | Database dialect: `postgres`, `mysql`, or `sqlite` (auto-detected) |
+| `--dialect <name>` | Database dialect: `postgres`, `mysql`, `sqlite`, or `mssql` (auto-detected) |
 | `--out <path>` | Output file (default: `./db.d.ts`) |
 | `--schema <name>` | Schema to introspect (repeatable) |
 | `--url <string>` | Database URL (overrides `DATABASE_URL`) |
@@ -97,6 +104,13 @@ export interface DB {
 - JSON columns mapped to `JsonValue`
 - Simple type affinity mapping (no ColumnType wrappers)
 
+### MSSQL
+- `Generated<T>` for identity and computed columns
+- Views
+- Multi-schema support (default: `dbo`)
+- All MSSQL types: `uniqueidentifier`, `datetime2`, `datetimeoffset`, `money`, `xml`, `varbinary`, etc.
+- Both URL (`mssql://`) and ADO.NET connection string formats
+
 ## Type Mappings
 
 Types are generated to match the default behavior of each database driver. If you customize your driver's type parsers, the generated types may not match.
@@ -150,6 +164,25 @@ Generated types match `better-sqlite3` defaults. SQLite has simpler type affinit
 | `DATE`, `DATETIME`, `TIMESTAMP` | `string` |
 | `JSON` | `JsonValue` |
 | `BOOLEAN` | `number` (0/1) |
+
+### MSSQL
+
+Generated types match `tedious` defaults. The driver handles type conversions, so simple types are used without `ColumnType` wrappers.
+
+| MSSQL | TypeScript |
+|-------|------------|
+| `int`, `smallint`, `tinyint`, `bigint` | `number` |
+| `decimal`, `numeric`, `money`, `smallmoney` | `number` |
+| `float`, `real` | `number` |
+| `datetime`, `datetime2`, `date`, `time` | `Date` |
+| `datetimeoffset`, `smalldatetime` | `Date` |
+| `char`, `varchar`, `nchar`, `nvarchar` | `string` |
+| `text`, `ntext` | `string` |
+| `uniqueidentifier` | `string` |
+| `xml` | `string` |
+| `bit` | `boolean` |
+| `binary`, `varbinary`, `image` | `Buffer` |
+| `sql_variant` | `unknown` |
 
 ## License
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,26 +12,73 @@
         "pg": "^8.16.3",
       },
       "devDependencies": {
+        "@tediousjs/connection-string": "^0.5.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/bun": "^1.1.12",
         "@types/micromatch": "^4.0.10",
         "@types/pg": "^8.11.10",
         "better-sqlite3": "^12.5.0",
         "mysql2": "^3.11.0",
+        "tarn": "^3.0.2",
+        "tedious": "^18.0.0",
         "typescript": "^5.6.3",
       },
       "peerDependencies": {
+        "better-sqlite3": ">=9.0.0 <13.0.0",
         "kysely": ">=0.27.0 <1.0.0",
         "mysql2": ">=3.0.0 <4.0.0",
         "pg": ">=8.8.0 <9.0.0",
+        "tarn": ">=3.0.0 <4.0.0",
+        "tedious": ">=16.0.0 <19.0.0",
       },
       "optionalPeers": [
+        "better-sqlite3",
         "mysql2",
         "pg",
+        "tarn",
+        "tedious",
       ],
     },
   },
   "packages": {
+    "@azure-rest/core-client": ["@azure-rest/core-client@2.5.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.10.0", "@azure/core-rest-pipeline": "^1.22.0", "@azure/core-tracing": "^1.3.0", "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-EHaOXW0RYDKS5CFffnixdyRPak5ytiCtU7uXDcP/uiY+A6jFRwNGzzJBiznkCzvi5EYpY+YWinieqHb0oY916A=="],
+
+    "@azure/abort-controller": ["@azure/abort-controller@2.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA=="],
+
+    "@azure/core-auth": ["@azure/core-auth@1.10.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-util": "^1.13.0", "tslib": "^2.6.2" } }, "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg=="],
+
+    "@azure/core-client": ["@azure/core-client@1.10.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.10.0", "@azure/core-rest-pipeline": "^1.22.0", "@azure/core-tracing": "^1.3.0", "@azure/core-util": "^1.13.0", "@azure/logger": "^1.3.0", "tslib": "^2.6.2" } }, "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w=="],
+
+    "@azure/core-http-compat": ["@azure/core-http-compat@2.3.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-client": "^1.10.0", "@azure/core-rest-pipeline": "^1.22.0" } }, "sha512-az9BkXND3/d5VgdRRQVkiJb2gOmDU8Qcq4GvjtBmDICNiQ9udFmDk4ZpSB5Qq1OmtDJGlQAfBaS4palFsazQ5g=="],
+
+    "@azure/core-lro": ["@azure/core-lro@2.7.2", "", { "dependencies": { "@azure/abort-controller": "^2.0.0", "@azure/core-util": "^1.2.0", "@azure/logger": "^1.0.0", "tslib": "^2.6.2" } }, "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw=="],
+
+    "@azure/core-paging": ["@azure/core-paging@1.6.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA=="],
+
+    "@azure/core-rest-pipeline": ["@azure/core-rest-pipeline@1.22.2", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.10.0", "@azure/core-tracing": "^1.3.0", "@azure/core-util": "^1.13.0", "@azure/logger": "^1.3.0", "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-MzHym+wOi8CLUlKCQu12de0nwcq9k9Kuv43j4Wa++CsCpJwps2eeBQwD2Bu8snkxTtDKDx4GwjuR9E8yC8LNrg=="],
+
+    "@azure/core-tracing": ["@azure/core-tracing@1.3.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ=="],
+
+    "@azure/core-util": ["@azure/core-util@1.13.1", "", { "dependencies": { "@azure/abort-controller": "^2.1.2", "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A=="],
+
+    "@azure/identity": ["@azure/identity@4.13.0", "", { "dependencies": { "@azure/abort-controller": "^2.0.0", "@azure/core-auth": "^1.9.0", "@azure/core-client": "^1.9.2", "@azure/core-rest-pipeline": "^1.17.0", "@azure/core-tracing": "^1.0.0", "@azure/core-util": "^1.11.0", "@azure/logger": "^1.0.0", "@azure/msal-browser": "^4.2.0", "@azure/msal-node": "^3.5.0", "open": "^10.1.0", "tslib": "^2.2.0" } }, "sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw=="],
+
+    "@azure/keyvault-common": ["@azure/keyvault-common@2.0.0", "", { "dependencies": { "@azure/abort-controller": "^2.0.0", "@azure/core-auth": "^1.3.0", "@azure/core-client": "^1.5.0", "@azure/core-rest-pipeline": "^1.8.0", "@azure/core-tracing": "^1.0.0", "@azure/core-util": "^1.10.0", "@azure/logger": "^1.1.4", "tslib": "^2.2.0" } }, "sha512-wRLVaroQtOqfg60cxkzUkGKrKMsCP6uYXAOomOIysSMyt1/YM0eUn9LqieAWM8DLcU4+07Fio2YGpPeqUbpP9w=="],
+
+    "@azure/keyvault-keys": ["@azure/keyvault-keys@4.10.0", "", { "dependencies": { "@azure-rest/core-client": "^2.3.3", "@azure/abort-controller": "^2.1.2", "@azure/core-auth": "^1.9.0", "@azure/core-http-compat": "^2.2.0", "@azure/core-lro": "^2.7.2", "@azure/core-paging": "^1.6.2", "@azure/core-rest-pipeline": "^1.19.0", "@azure/core-tracing": "^1.2.0", "@azure/core-util": "^1.11.0", "@azure/keyvault-common": "^2.0.0", "@azure/logger": "^1.1.4", "tslib": "^2.8.1" } }, "sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag=="],
+
+    "@azure/logger": ["@azure/logger@1.3.0", "", { "dependencies": { "@typespec/ts-http-runtime": "^0.3.0", "tslib": "^2.6.2" } }, "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA=="],
+
+    "@azure/msal-browser": ["@azure/msal-browser@4.27.0", "", { "dependencies": { "@azure/msal-common": "15.13.3" } }, "sha512-bZ8Pta6YAbdd0o0PEaL1/geBsPrLEnyY/RDWqvF1PP9RUH8EMLvUMGoZFYS6jSlUan6KZ9IMTLCnwpWWpQRK/w=="],
+
+    "@azure/msal-common": ["@azure/msal-common@15.13.3", "", {}, "sha512-shSDU7Ioecya+Aob5xliW9IGq1Ui8y4EVSdWGyI1Gbm4Vg61WpP95LuzcY214/wEjSn6w4PZYD4/iVldErHayQ=="],
+
+    "@azure/msal-node": ["@azure/msal-node@3.8.4", "", { "dependencies": { "@azure/msal-common": "15.13.3", "jsonwebtoken": "^9.0.0", "uuid": "^8.3.0" } }, "sha512-lvuAwsDpPDE/jSuVQOBMpLbXuVuLsPNRwWCyK3/6bPlBk0fGWegqoZ0qjZclMWyQ2JNvIY3vHY7hoFmFmFQcOw=="],
+
+    "@js-joda/core": ["@js-joda/core@5.6.5", "", {}, "sha512-3zwefSMwHpu8iVUW8YYz227sIv6UFqO31p1Bf1ZH/Vom7CmNyUsXjDBlnNzcuhmOL1XfxZ3nvND42kR23XlbcQ=="],
+
+    "@tediousjs/connection-string": ["@tediousjs/connection-string@0.5.0", "", {}, "sha512-7qSgZbincDDDFyRweCIEvZULFAw5iz/DeunhvuxpL31nfntX3P4Yd4HkHBRg9H8CdqY1e5WFN1PZIz/REL9MVQ=="],
+
     "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
 
     "@types/braces": ["@types/braces@3.0.5", "", {}, "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w=="],
@@ -44,6 +91,14 @@
 
     "@types/pg": ["@types/pg@8.16.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ=="],
 
+    "@types/readable-stream": ["@types/readable-stream@4.0.23", "", { "dependencies": { "@types/node": "*" } }, "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig=="],
+
+    "@typespec/ts-http-runtime": ["@typespec/ts-http-runtime@0.3.2", "", { "dependencies": { "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "tslib": "^2.6.2" } }, "sha512-IlqQ/Gv22xUC1r/WQm4StLkYQmaaTsXAhUVsNE0+xiyf0yRFiH5++q78U3bw6bLKDCTmh0uqKB9eG9+Bt75Dkg=="],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
@@ -54,13 +109,17 @@
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
-    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+    "bl": ["bl@6.1.6", "", { "dependencies": { "@types/readable-stream": "^4.0.0", "buffer": "^6.0.3", "inherits": "^2.0.4", "readable-stream": "^4.2.0" } }, "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -72,15 +131,29 @@
 
     "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
 
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
+
+    "default-browser": ["default-browser@5.4.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
@@ -96,6 +169,10 @@
 
     "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "iconv-lite": ["iconv-lite@0.7.1", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
@@ -103,6 +180,10 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
     "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
 
@@ -112,7 +193,31 @@
 
     "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
+    "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
+
+    "js-md4": ["js-md4@0.3.2", "", {}, "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA=="],
+
+    "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
     "kysely": ["kysely@0.27.6", "", {}, "sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ=="],
+
+    "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
+
+    "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
+
+    "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
+
+    "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="],
+
+    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
+
+    "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
+
+    "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
 
     "log-symbols": ["log-symbols@7.0.1", "", { "dependencies": { "is-unicode-supported": "^2.0.0", "yoctocolors": "^2.1.1" } }, "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg=="],
 
@@ -130,17 +235,23 @@
 
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
     "mysql2": ["mysql2@3.16.0", "", { "dependencies": { "aws-ssl-profiles": "^1.1.1", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.0", "long": "^5.2.1", "lru.min": "^1.0.0", "named-placeholders": "^1.1.3", "seq-queue": "^0.0.5", "sqlstring": "^2.3.2" } }, "sha512-AEGW7QLLSuSnjCS4pk3EIqOmogegmze9h8EyrndavUQnIUcfkVal/sK7QznE+a3bc6rzPbAiui9Jcb+96tPwYA=="],
 
     "named-placeholders": ["named-placeholders@1.1.6", "", { "dependencies": { "lru.min": "^1.1.0" } }, "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="],
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
+    "native-duplexpair": ["native-duplexpair@1.0.0", "", {}, "sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA=="],
+
     "node-abi": ["node-abi@3.85.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
     "ora": ["ora@9.0.0", "", { "dependencies": { "chalk": "^5.6.2", "cli-cursor": "^5.0.0", "cli-spinners": "^3.2.0", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.1.0", "log-symbols": "^7.0.1", "stdin-discarder": "^0.2.2", "string-width": "^8.1.0", "strip-ansi": "^7.1.2" } }, "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A=="],
 
@@ -172,13 +283,17 @@
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
     "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
-    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
@@ -196,6 +311,8 @@
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
     "sqlstring": ["sqlstring@2.3.3", "", {}, "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
@@ -212,7 +329,13 @@
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
+    "tarn": ["tarn@3.0.2", "", {}, "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ=="],
+
+    "tedious": ["tedious@18.6.2", "", { "dependencies": { "@azure/core-auth": "^1.7.2", "@azure/identity": "^4.2.1", "@azure/keyvault-keys": "^4.4.0", "@js-joda/core": "^5.6.1", "@types/node": ">=18", "bl": "^6.0.11", "iconv-lite": "^0.6.3", "js-md4": "^0.3.2", "native-duplexpair": "^1.0.0", "sprintf-js": "^1.1.3" } }, "sha512-g7jC56o3MzLkE3lHkaFe2ZdOVFBahq5bsB60/M4NYUbocw/MCrS89IOEQUFr+ba6pb8ZHczZ/VqCyYeYq0xBAg=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
@@ -222,10 +345,22 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
+    "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
+
+    "tar-stream/bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
+    "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "tedious/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "tar-stream/bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,19 @@ services:
       interval: 2s
       timeout: 5s
       retries: 10
+
+  mssql:
+    build:
+      context: ./test/fixtures/mssql
+      dockerfile: Dockerfile
+    container_name: kysely-gen-test-mssql
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: Test_Password123
+    ports:
+      - '1434:1433'
+    healthcheck:
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P Test_Password123 -C -Q "SELECT 1 FROM test_db.sys.tables" || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 20

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kysely-gen",
   "version": "0.6.1",
-  "description": "Database type generator for Kysely - Supports PostgreSQL, MySQL, and SQLite",
+  "description": "Database type generator for Kysely - Supports PostgreSQL, MySQL, SQLite, and MSSQL",
   "type": "module",
   "license": "MIT",
   "author": "kysely-gen contributors",
@@ -19,6 +19,8 @@
     "postgresql",
     "mysql",
     "sqlite",
+    "mssql",
+    "sqlserver",
     "typescript",
     "codegen",
     "typegen",
@@ -62,19 +64,24 @@
     "pg": "^8.16.3"
   },
   "devDependencies": {
+    "@tediousjs/connection-string": "^0.5.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/bun": "^1.1.12",
     "@types/micromatch": "^4.0.10",
     "@types/pg": "^8.11.10",
     "better-sqlite3": "^12.5.0",
     "mysql2": "^3.11.0",
+    "tarn": "^3.0.2",
+    "tedious": "^18.0.0",
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
     "kysely": ">=0.27.0 <1.0.0",
     "pg": ">=8.8.0 <9.0.0",
     "mysql2": ">=3.0.0 <4.0.0",
-    "better-sqlite3": ">=9.0.0 <13.0.0"
+    "better-sqlite3": ">=9.0.0 <13.0.0",
+    "tedious": ">=16.0.0 <19.0.0",
+    "tarn": ">=3.0.0 <4.0.0"
   },
   "peerDependenciesMeta": {
     "pg": {
@@ -84,6 +91,12 @@
       "optional": true
     },
     "better-sqlite3": {
+      "optional": true
+    },
+    "tedious": {
+      "optional": true
+    },
+    "tarn": {
       "optional": true
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,8 +80,8 @@ async function generate(options: {
 
   let dialectName: DialectName;
   if (options.dialect) {
-    if (options.dialect !== 'postgres' && options.dialect !== 'mysql' && options.dialect !== 'sqlite') {
-      console.error(chalk.red(`Error: Unknown dialect '${options.dialect}'. Supported: postgres, mysql, sqlite`));
+    if (options.dialect !== 'postgres' && options.dialect !== 'mysql' && options.dialect !== 'sqlite' && options.dialect !== 'mssql') {
+      console.error(chalk.red(`Error: Unknown dialect '${options.dialect}'. Supported: postgres, mysql, sqlite, mssql`));
       process.exit(1);
     }
     dialectName = options.dialect;
@@ -96,7 +96,7 @@ async function generate(options: {
 
   const dialect = getDialect(dialectName);
   const outputPath = options.out;
-  const defaultSchema = dialectName === 'sqlite' ? 'main' : 'public';
+  const defaultSchema = dialectName === 'sqlite' ? 'main' : dialectName === 'mssql' ? 'dbo' : 'public';
   const schemas = options.schema.length > 0 ? options.schema : [defaultSchema];
 
   log('');

--- a/src/dialects/index.ts
+++ b/src/dialects/index.ts
@@ -2,6 +2,7 @@ import type { Dialect, DialectName } from './types';
 import { PostgresDialect } from './postgres';
 import { MysqlDialect } from './mysql';
 import { SqliteDialect } from './sqlite';
+import { MssqlDialect } from './mssql';
 
 export function getDialect(name: DialectName): Dialect {
   switch (name) {
@@ -11,6 +12,8 @@ export function getDialect(name: DialectName): Dialect {
       return new MysqlDialect();
     case 'sqlite':
       return new SqliteDialect();
+    case 'mssql':
+      return new MssqlDialect();
     default:
       throw new Error(`Unknown dialect: ${name}`);
   }
@@ -27,6 +30,11 @@ export function detectDialect(connectionString: string): DialectName | null {
     return 'sqlite';
   }
 
+  const lowerConnString = connectionString.toLowerCase();
+  if (lowerConnString.includes('server=') || lowerConnString.includes('data source=')) {
+    return 'mssql';
+  }
+
   try {
     const url = new URL(connectionString);
     const protocol = url.protocol.replace(':', '');
@@ -38,6 +46,9 @@ export function detectDialect(connectionString: string): DialectName | null {
       case 'mysql':
       case 'mysql2':
         return 'mysql';
+      case 'mssql':
+      case 'sqlserver':
+        return 'mssql';
       default:
         return null;
     }
@@ -49,4 +60,5 @@ export function detectDialect(connectionString: string): DialectName | null {
 export { PostgresDialect } from './postgres';
 export { MysqlDialect } from './mysql';
 export { SqliteDialect } from './sqlite';
+export { MssqlDialect } from './mssql';
 export type { Dialect, DialectName, IntrospectOptions, MapTypeOptions } from './types';

--- a/src/dialects/mssql/index.ts
+++ b/src/dialects/mssql/index.ts
@@ -1,0 +1,110 @@
+import { MssqlDialect as KyselyMssqlDialect } from 'kysely';
+import type { Kysely, Dialect as KyselyDialect } from 'kysely';
+import type { Dialect, IntrospectOptions, MapTypeOptions } from '@/dialects/types';
+import type { DatabaseMetadata } from '@/introspect/types';
+import type { TypeNode } from '@/ast/nodes';
+import { introspectMssql } from './introspect';
+import { mapMssqlType } from './type-mapper';
+
+const DEFAULT_MSSQL_PORT = 1433;
+
+type ConnectionConfig = {
+  server: string;
+  port: number | undefined;
+  instanceName: string | undefined;
+  database: string;
+  userName: string;
+  password: string;
+};
+
+export class MssqlDialect implements Dialect {
+  readonly name = 'mssql' as const;
+
+  async createKyselyDialect(connectionString: string): Promise<KyselyDialect> {
+    const tarn = await import('tarn');
+    const tedious = await import('tedious');
+
+    const config = await this.parseConnectionString(connectionString);
+
+    return new KyselyMssqlDialect({
+      tarn: {
+        ...tarn,
+        options: { min: 0, max: 1 },
+      },
+      tedious: {
+        ...tedious,
+        connectionFactory: () => {
+          return new tedious.Connection({
+            authentication: {
+              options: { password: config.password, userName: config.userName },
+              type: 'default',
+            },
+            options: {
+              database: config.database,
+              encrypt: true,
+              instanceName: config.instanceName,
+              port: config.port,
+              trustServerCertificate: true,
+            },
+            server: config.server,
+          });
+        },
+      },
+    });
+  }
+
+  async introspect(db: Kysely<any>, options: IntrospectOptions): Promise<DatabaseMetadata> {
+    return introspectMssql(db, options);
+  }
+
+  mapType(dataType: string, options: MapTypeOptions): TypeNode {
+    return mapMssqlType(dataType, options);
+  }
+
+  private async parseConnectionString(connectionString: string): Promise<ConnectionConfig> {
+    if (connectionString.startsWith('mssql://') || connectionString.startsWith('sqlserver://')) {
+      return this.parseUrlFormat(connectionString);
+    }
+
+    return this.parseAdoNetFormat(connectionString);
+  }
+
+  private parseUrlFormat(connectionString: string): ConnectionConfig {
+    const url = new URL(connectionString);
+    return {
+      server: url.hostname,
+      port: url.port ? parseInt(url.port, 10) : DEFAULT_MSSQL_PORT,
+      instanceName: undefined,
+      database: url.pathname.slice(1),
+      userName: decodeURIComponent(url.username),
+      password: decodeURIComponent(url.password),
+    };
+  }
+
+  private async parseAdoNetFormat(connectionString: string): Promise<ConnectionConfig> {
+    const { parseConnectionString } = await import('@tediousjs/connection-string');
+
+    const parsed = parseConnectionString(connectionString) as Record<string, string>;
+    const serverValue = parsed.server || parsed['data source'] || 'localhost';
+    const tokens = serverValue.split(',');
+    const serverAndInstance = tokens[0]!.split('\\');
+    const server = serverAndInstance[0]!;
+    const instanceName = serverAndInstance[1];
+
+    const port =
+      instanceName === undefined
+        ? tokens[1]
+          ? parseInt(tokens[1], 10)
+          : DEFAULT_MSSQL_PORT
+        : undefined;
+
+    return {
+      server,
+      port,
+      instanceName,
+      database: parsed.database || parsed['initial catalog'] || '',
+      userName: parsed['user id'] || '',
+      password: parsed.password || '',
+    };
+  }
+}

--- a/src/dialects/mssql/introspect.ts
+++ b/src/dialects/mssql/introspect.ts
@@ -1,0 +1,113 @@
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+import type { ColumnMetadata, DatabaseMetadata, TableMetadata } from '@/introspect/types';
+import type { IntrospectOptions } from '@/dialects/types';
+
+type RawColumn = {
+  TABLE_SCHEMA: string;
+  TABLE_NAME: string;
+  COLUMN_NAME: string;
+  DATA_TYPE: string;
+  IS_NULLABLE: string;
+  COLUMN_DEFAULT: string | null;
+  IS_IDENTITY: number;
+  IS_COMPUTED: number;
+};
+
+export async function introspectMssql(
+  db: Kysely<any>,
+  options: IntrospectOptions,
+): Promise<DatabaseMetadata> {
+  const [baseTables, views] = await Promise.all([
+    introspectTables(db, options.schemas),
+    introspectViews(db, options.schemas),
+  ]);
+
+  const tables = [...baseTables, ...views];
+
+  return {
+    tables,
+    enums: [],
+  };
+}
+
+async function introspectTables(db: Kysely<any>, schemas: string[]): Promise<TableMetadata[]> {
+  const rawColumns = await sql<RawColumn>`
+    SELECT
+      c.TABLE_SCHEMA,
+      c.TABLE_NAME,
+      c.COLUMN_NAME,
+      c.DATA_TYPE,
+      c.IS_NULLABLE,
+      c.COLUMN_DEFAULT,
+      COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity') AS IS_IDENTITY,
+      COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA + '.' + c.TABLE_NAME), c.COLUMN_NAME, 'IsComputed') AS IS_COMPUTED
+    FROM INFORMATION_SCHEMA.COLUMNS c
+    INNER JOIN INFORMATION_SCHEMA.TABLES t
+      ON c.TABLE_SCHEMA = t.TABLE_SCHEMA
+      AND c.TABLE_NAME = t.TABLE_NAME
+    WHERE t.TABLE_TYPE = 'BASE TABLE'
+      AND c.TABLE_SCHEMA IN (${sql.join(schemas.map(s => sql`${s}`))})
+    ORDER BY c.TABLE_SCHEMA, c.TABLE_NAME, c.ORDINAL_POSITION
+  `.execute(db);
+
+  return buildTableMetadata(rawColumns.rows, false);
+}
+
+async function introspectViews(db: Kysely<any>, schemas: string[]): Promise<TableMetadata[]> {
+  const rawColumns = await sql<RawColumn>`
+    SELECT
+      c.TABLE_SCHEMA,
+      c.TABLE_NAME,
+      c.COLUMN_NAME,
+      c.DATA_TYPE,
+      c.IS_NULLABLE,
+      c.COLUMN_DEFAULT,
+      0 AS IS_IDENTITY,
+      0 AS IS_COMPUTED
+    FROM INFORMATION_SCHEMA.COLUMNS c
+    INNER JOIN INFORMATION_SCHEMA.VIEWS v
+      ON c.TABLE_SCHEMA = v.TABLE_SCHEMA
+      AND c.TABLE_NAME = v.TABLE_NAME
+    WHERE c.TABLE_SCHEMA IN (${sql.join(schemas.map(s => sql`${s}`))})
+    ORDER BY c.TABLE_SCHEMA, c.TABLE_NAME, c.ORDINAL_POSITION
+  `.execute(db);
+
+  return buildTableMetadata(rawColumns.rows, true);
+}
+
+function buildTableMetadata(rows: RawColumn[], isView: boolean): TableMetadata[] {
+  const tableMap = new Map<string, TableMetadata>();
+
+  for (const row of rows) {
+    const tableKey = `${row.TABLE_SCHEMA}.${row.TABLE_NAME}`;
+
+    if (!tableMap.has(tableKey)) {
+      tableMap.set(tableKey, {
+        schema: row.TABLE_SCHEMA,
+        name: row.TABLE_NAME,
+        columns: [],
+        ...(isView && { isView: true }),
+      });
+    }
+
+    const table = tableMap.get(tableKey);
+    if (table) {
+      const isAutoIncrement = row.IS_IDENTITY === 1;
+      const isComputed = row.IS_COMPUTED === 1;
+
+      const columnMetadata: ColumnMetadata = {
+        name: row.COLUMN_NAME,
+        dataType: row.DATA_TYPE.toLowerCase(),
+        dataTypeSchema: row.TABLE_SCHEMA,
+        isNullable: row.IS_NULLABLE === 'YES',
+        isAutoIncrement: isView ? false : (isAutoIncrement || isComputed),
+        hasDefaultValue: row.COLUMN_DEFAULT !== null || isAutoIncrement || isComputed,
+      };
+
+      table.columns.push(columnMetadata);
+    }
+  }
+
+  return Array.from(tableMap.values());
+}

--- a/src/dialects/mssql/type-mapper.ts
+++ b/src/dialects/mssql/type-mapper.ts
@@ -1,0 +1,83 @@
+import type { TypeNode } from '@/ast/nodes';
+import type { MapTypeOptions } from '@/dialects/types';
+
+export function mapMssqlType(dataType: string, options: MapTypeOptions): TypeNode {
+  const { isNullable, unknownTypes } = options;
+
+  let baseType: TypeNode;
+  const lowerType = dataType.toLowerCase();
+
+  switch (lowerType) {
+    case 'tinyint':
+    case 'smallint':
+    case 'int':
+    case 'bigint':
+      baseType = { kind: 'primitive', value: 'number' };
+      break;
+
+    case 'float':
+    case 'real':
+      baseType = { kind: 'primitive', value: 'number' };
+      break;
+
+    case 'decimal':
+    case 'numeric':
+    case 'money':
+    case 'smallmoney':
+      baseType = { kind: 'primitive', value: 'number' };
+      break;
+
+    case 'char':
+    case 'varchar':
+    case 'nchar':
+    case 'nvarchar':
+    case 'text':
+    case 'ntext':
+      baseType = { kind: 'primitive', value: 'string' };
+      break;
+
+    case 'uniqueidentifier':
+    case 'xml':
+      baseType = { kind: 'primitive', value: 'string' };
+      break;
+
+    case 'binary':
+    case 'varbinary':
+    case 'image':
+      baseType = { kind: 'primitive', value: 'Buffer' };
+      break;
+
+    case 'bit':
+      baseType = { kind: 'primitive', value: 'boolean' };
+      break;
+
+    case 'date':
+    case 'datetime':
+    case 'datetime2':
+    case 'smalldatetime':
+    case 'time':
+    case 'datetimeoffset':
+      baseType = { kind: 'primitive', value: 'Date' };
+      break;
+
+    case 'sql_variant':
+    case 'tvp':
+      baseType = { kind: 'primitive', value: 'unknown' };
+      break;
+
+    default:
+      if (unknownTypes) {
+        unknownTypes.add(dataType);
+      }
+      baseType = { kind: 'primitive', value: 'unknown' };
+  }
+
+  if (isNullable) {
+    return {
+      kind: 'union',
+      types: [baseType, { kind: 'primitive', value: 'null' }],
+    };
+  }
+
+  return baseType;
+}

--- a/src/dialects/types.ts
+++ b/src/dialects/types.ts
@@ -2,7 +2,7 @@ import type { Kysely, Dialect as KyselyDialect } from 'kysely';
 import type { TypeNode } from '@/ast/nodes';
 import type { DatabaseMetadata } from '@/introspect/types';
 
-export type DialectName = 'postgres' | 'mysql' | 'sqlite';
+export type DialectName = 'postgres' | 'mysql' | 'sqlite' | 'mssql';
 
 export type IntrospectOptions = {
   schemas: string[];

--- a/test/dialects/mssql/connection-string.test.ts
+++ b/test/dialects/mssql/connection-string.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test';
+import { MssqlDialect } from '@/dialects/mssql';
+
+describe('MSSQL Connection String Parsing', () => {
+  const dialect = new MssqlDialect();
+
+  describe('URL format', () => {
+    test('should parse basic mssql:// URL', async () => {
+      const config = await (dialect as any).parseConnectionString(
+        'mssql://user:pass@localhost:1433/mydb'
+      );
+
+      expect(config.server).toBe('localhost');
+      expect(config.port).toBe(1433);
+      expect(config.database).toBe('mydb');
+      expect(config.userName).toBe('user');
+      expect(config.password).toBe('pass');
+      expect(config.instanceName).toBeUndefined();
+    });
+
+    test('should parse sqlserver:// URL', async () => {
+      const config = await (dialect as any).parseConnectionString(
+        'sqlserver://admin:secret@dbserver:1434/production'
+      );
+
+      expect(config.server).toBe('dbserver');
+      expect(config.port).toBe(1434);
+      expect(config.database).toBe('production');
+      expect(config.userName).toBe('admin');
+      expect(config.password).toBe('secret');
+    });
+
+    test('should use default port 1433 when not specified', async () => {
+      const config = await (dialect as any).parseConnectionString(
+        'mssql://user:pass@localhost/mydb'
+      );
+
+      expect(config.port).toBe(1433);
+    });
+
+    test('should decode URL-encoded credentials', async () => {
+      const config = await (dialect as any).parseConnectionString(
+        'mssql://user%40domain:p%40ss%2Fword@localhost/mydb'
+      );
+
+      expect(config.userName).toBe('user@domain');
+      expect(config.password).toBe('p@ss/word');
+    });
+  });
+
+  describe('ADO.NET format', () => {
+    test('should parse basic ADO.NET connection string', async () => {
+      const config = await (dialect as any).parseConnectionString(
+        'Server=localhost;Database=mydb;User Id=user;Password=pass;'
+      );
+
+      expect(config.server).toBe('localhost');
+      expect(config.database).toBe('mydb');
+      expect(config.userName).toBe('user');
+      expect(config.password).toBe('pass');
+    });
+
+    test('should parse connection string with port in Server', async () => {
+      const config = await (dialect as any).parseConnectionString(
+        'Server=localhost,1434;Database=mydb;User Id=user;Password=pass;'
+      );
+
+      expect(config.server).toBe('localhost');
+      expect(config.port).toBe(1434);
+    });
+
+    test('should parse connection string with instance name', async () => {
+      const config = await (dialect as any).parseConnectionString(
+        'Server=localhost\\SQLEXPRESS;Database=mydb;User Id=user;Password=pass;'
+      );
+
+      expect(config.server).toBe('localhost');
+      expect(config.instanceName).toBe('SQLEXPRESS');
+      expect(config.port).toBeUndefined();
+    });
+
+    test('should parse Data Source alias', async () => {
+      const config = await (dialect as any).parseConnectionString(
+        'Data Source=dbserver;Database=mydb;User Id=user;Password=pass;'
+      );
+
+      expect(config.server).toBe('dbserver');
+    });
+
+    test('should parse Initial Catalog alias', async () => {
+      const config = await (dialect as any).parseConnectionString(
+        'Server=localhost;Initial Catalog=mydb;User Id=user;Password=pass;'
+      );
+
+      expect(config.database).toBe('mydb');
+    });
+  });
+});

--- a/test/dialects/mssql/type-mapper.test.ts
+++ b/test/dialects/mssql/type-mapper.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'bun:test';
+import { mapMssqlType } from '@/dialects/mssql/type-mapper';
+
+describe('MSSQL Type Mapper', () => {
+  describe('integer types', () => {
+    test('should map integer types to number', () => {
+      expect(mapMssqlType('tinyint', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapMssqlType('smallint', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapMssqlType('int', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapMssqlType('bigint', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+    });
+  });
+
+  describe('floating point types', () => {
+    test('should map float/real to number', () => {
+      expect(mapMssqlType('float', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapMssqlType('real', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+    });
+  });
+
+  describe('decimal types', () => {
+    test('should map decimal/numeric/money to number', () => {
+      expect(mapMssqlType('decimal', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapMssqlType('numeric', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapMssqlType('money', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapMssqlType('smallmoney', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+    });
+  });
+
+  describe('string types', () => {
+    test('should map string types to string', () => {
+      expect(mapMssqlType('char', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+      expect(mapMssqlType('varchar', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+      expect(mapMssqlType('nchar', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+      expect(mapMssqlType('nvarchar', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+      expect(mapMssqlType('text', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+      expect(mapMssqlType('ntext', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+    });
+
+    test('should map uniqueidentifier to string', () => {
+      expect(mapMssqlType('uniqueidentifier', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+    });
+
+    test('should map xml to string', () => {
+      expect(mapMssqlType('xml', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+    });
+  });
+
+  describe('binary types', () => {
+    test('should map binary types to Buffer', () => {
+      expect(mapMssqlType('binary', { isNullable: false })).toEqual({ kind: 'primitive', value: 'Buffer' });
+      expect(mapMssqlType('varbinary', { isNullable: false })).toEqual({ kind: 'primitive', value: 'Buffer' });
+      expect(mapMssqlType('image', { isNullable: false })).toEqual({ kind: 'primitive', value: 'Buffer' });
+    });
+  });
+
+  describe('boolean type', () => {
+    test('should map bit to boolean', () => {
+      expect(mapMssqlType('bit', { isNullable: false })).toEqual({ kind: 'primitive', value: 'boolean' });
+    });
+  });
+
+  describe('date/time types', () => {
+    test('should map date/time types to Date', () => {
+      expect(mapMssqlType('date', { isNullable: false })).toEqual({ kind: 'primitive', value: 'Date' });
+      expect(mapMssqlType('datetime', { isNullable: false })).toEqual({ kind: 'primitive', value: 'Date' });
+      expect(mapMssqlType('datetime2', { isNullable: false })).toEqual({ kind: 'primitive', value: 'Date' });
+      expect(mapMssqlType('smalldatetime', { isNullable: false })).toEqual({ kind: 'primitive', value: 'Date' });
+      expect(mapMssqlType('time', { isNullable: false })).toEqual({ kind: 'primitive', value: 'Date' });
+      expect(mapMssqlType('datetimeoffset', { isNullable: false })).toEqual({ kind: 'primitive', value: 'Date' });
+    });
+  });
+
+  describe('special types', () => {
+    test('should map sql_variant to unknown', () => {
+      expect(mapMssqlType('sql_variant', { isNullable: false })).toEqual({ kind: 'primitive', value: 'unknown' });
+    });
+
+    test('should map tvp to unknown', () => {
+      expect(mapMssqlType('tvp', { isNullable: false })).toEqual({ kind: 'primitive', value: 'unknown' });
+    });
+  });
+
+  describe('nullable types', () => {
+    test('should wrap nullable types in union with null', () => {
+      const result = mapMssqlType('int', { isNullable: true });
+      expect(result).toEqual({
+        kind: 'union',
+        types: [
+          { kind: 'primitive', value: 'number' },
+          { kind: 'primitive', value: 'null' },
+        ],
+      });
+    });
+
+    test('should wrap Date types in union with null', () => {
+      const result = mapMssqlType('datetime', { isNullable: true });
+      expect(result).toEqual({
+        kind: 'union',
+        types: [
+          { kind: 'primitive', value: 'Date' },
+          { kind: 'primitive', value: 'null' },
+        ],
+      });
+    });
+  });
+
+  describe('unknown types', () => {
+    test('should map unknown types to unknown', () => {
+      expect(mapMssqlType('custom_type', { isNullable: false })).toEqual({ kind: 'primitive', value: 'unknown' });
+    });
+
+    test('should track unknown types', () => {
+      const unknownTypes = new Set<string>();
+      mapMssqlType('my_custom_type', { isNullable: false, unknownTypes });
+      expect(unknownTypes.has('my_custom_type')).toBe(true);
+    });
+  });
+
+  describe('case insensitivity', () => {
+    test('should handle uppercase type names', () => {
+      expect(mapMssqlType('INT', { isNullable: false })).toEqual({ kind: 'primitive', value: 'number' });
+      expect(mapMssqlType('VARCHAR', { isNullable: false })).toEqual({ kind: 'primitive', value: 'string' });
+      expect(mapMssqlType('DATETIME2', { isNullable: false })).toEqual({ kind: 'primitive', value: 'Date' });
+    });
+  });
+});

--- a/test/fixtures/mssql/Dockerfile
+++ b/test/fixtures/mssql/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/mssql/server:2022-latest
+
+USER root
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /entrypoint.sh
+COPY init.sql /init.sql
+
+RUN chmod 755 /entrypoint.sh /init.sql && chown mssql:root /entrypoint.sh /init.sql
+
+USER mssql
+
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/test/fixtures/mssql/entrypoint.sh
+++ b/test/fixtures/mssql/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Start SQL Server in the background
+/opt/mssql/bin/sqlservr &
+
+# Wait for SQL Server to be ready
+echo "Waiting for SQL Server to start..."
+for i in {1..60}; do
+    /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C -Q "SELECT 1" > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        echo "SQL Server is ready."
+        break
+    fi
+    echo "Waiting... ($i/60)"
+    sleep 1
+done
+
+# Run init script if it exists and hasn't been run
+if [ -f /init.sql ]; then
+    if [ ! -f /var/opt/mssql/.initialized ]; then
+        echo "Running init script..."
+        /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -C -i /init.sql
+        if [ $? -eq 0 ]; then
+            touch /var/opt/mssql/.initialized
+            echo "Database initialized successfully."
+        else
+            echo "Failed to initialize database."
+        fi
+    else
+        echo "Database already initialized, skipping."
+    fi
+fi
+
+# Keep container running
+wait

--- a/test/fixtures/mssql/init.sql
+++ b/test/fixtures/mssql/init.sql
@@ -1,0 +1,162 @@
+-- Test database schema for MSSQL
+SET QUOTED_IDENTIFIER ON;
+GO
+
+USE master;
+GO
+
+IF DB_ID('test_db') IS NOT NULL
+  DROP DATABASE test_db;
+GO
+
+CREATE DATABASE test_db;
+GO
+
+USE test_db;
+GO
+
+-- Create test schema
+CREATE SCHEMA test_schema;
+GO
+
+-- Users table
+CREATE TABLE users (
+  id INT IDENTITY(1,1) PRIMARY KEY,
+  email NVARCHAR(255) NOT NULL UNIQUE,
+  username NVARCHAR(100) NOT NULL,
+  created_at DATETIME2 NOT NULL DEFAULT GETDATE(),
+  updated_at DATETIME2 NULL,
+  is_active BIT NOT NULL DEFAULT 1,
+  metadata NVARCHAR(MAX) NULL,
+  age INT NULL,
+  balance DECIMAL(10, 2) NULL
+);
+GO
+
+-- Posts table
+CREATE TABLE posts (
+  id INT IDENTITY(1,1) PRIMARY KEY,
+  user_id INT NOT NULL,
+  title NVARCHAR(255) NOT NULL,
+  content NVARCHAR(MAX) NULL,
+  published_at DATETIME2 NULL,
+  view_count INT NOT NULL DEFAULT 0,
+  status NVARCHAR(20) NOT NULL DEFAULT 'draft',
+  CONSTRAINT fk_posts_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  CONSTRAINT chk_posts_status CHECK (status IN ('draft', 'published', 'archived'))
+);
+GO
+
+-- Comments table
+CREATE TABLE comments (
+  id INT IDENTITY(1,1) PRIMARY KEY,
+  post_id INT NOT NULL,
+  user_id INT NOT NULL,
+  content NVARCHAR(MAX) NOT NULL,
+  status NVARCHAR(20) NOT NULL DEFAULT 'pending',
+  created_at DATETIME2 NOT NULL DEFAULT GETDATE(),
+  CONSTRAINT fk_comments_post FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE,
+  CONSTRAINT fk_comments_user FOREIGN KEY (user_id) REFERENCES users(id),
+  CONSTRAINT chk_comments_status CHECK (status IN ('pending', 'approved', 'rejected'))
+);
+GO
+
+-- Table with binary types
+CREATE TABLE files (
+  id INT IDENTITY(1,1) PRIMARY KEY,
+  name NVARCHAR(255) NOT NULL,
+  content VARBINARY(MAX) NULL,
+  thumbnail VARBINARY(MAX) NULL,
+  checksum BINARY(32) NULL,
+  guid UNIQUEIDENTIFIER NOT NULL DEFAULT NEWID()
+);
+GO
+
+-- Table with various numeric types
+CREATE TABLE metrics (
+  id BIGINT IDENTITY(1,1) PRIMARY KEY,
+  tiny_val TINYINT NULL,
+  small_val SMALLINT NULL,
+  int_val INT NULL,
+  big_val BIGINT NULL,
+  float_val FLOAT NULL,
+  real_val REAL NULL,
+  decimal_val DECIMAL(15, 4) NULL,
+  money_val MONEY NULL,
+  smallmoney_val SMALLMONEY NULL
+);
+GO
+
+-- Table with date/time types
+CREATE TABLE events (
+  id INT IDENTITY(1,1) PRIMARY KEY,
+  name NVARCHAR(255) NOT NULL,
+  event_date DATE NULL,
+  event_time TIME NULL,
+  event_datetime DATETIME NULL,
+  event_datetime2 DATETIME2 NULL,
+  event_datetimeoffset DATETIMEOFFSET NULL,
+  event_smalldatetime SMALLDATETIME NULL
+);
+GO
+
+-- Table with special types
+CREATE TABLE special_types (
+  id INT IDENTITY(1,1) PRIMARY KEY,
+  xml_data XML NULL,
+  variant_data SQL_VARIANT NULL
+);
+GO
+
+-- Table with computed column
+CREATE TABLE orders (
+  id INT IDENTITY(1,1) PRIMARY KEY,
+  quantity INT NOT NULL,
+  unit_price DECIMAL(10, 2) NOT NULL,
+  total_price AS (quantity * unit_price) PERSISTED
+);
+GO
+
+-- Table in test_schema
+CREATE TABLE test_schema.tasks (
+  id INT IDENTITY(1,1) PRIMARY KEY,
+  title NVARCHAR(255) NOT NULL,
+  description NVARCHAR(MAX) NULL,
+  priority NVARCHAR(20) DEFAULT 'medium',
+  assignee_email NVARCHAR(255) NULL,
+  created_at DATETIME2 NOT NULL DEFAULT GETDATE(),
+  CONSTRAINT chk_tasks_priority CHECK (priority IN ('low', 'medium', 'high'))
+);
+GO
+
+-- Create a view in test_schema
+CREATE VIEW test_schema.active_tasks AS
+SELECT id, title, priority
+FROM test_schema.tasks
+WHERE priority = 'high';
+GO
+
+-- Create a view in dbo
+CREATE VIEW active_users AS
+SELECT
+  id,
+  email,
+  username,
+  created_at
+FROM users
+WHERE is_active = 1;
+GO
+
+-- Create view with join
+CREATE VIEW user_posts AS
+SELECT
+  u.id AS user_id,
+  u.username,
+  p.id AS post_id,
+  p.title
+FROM users u
+JOIN posts p ON u.id = p.user_id;
+GO
+
+PRINT 'MSSQL test database initialized successfully';
+GO

--- a/test/introspect/mssql.test.ts
+++ b/test/introspect/mssql.test.ts
@@ -1,0 +1,241 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { Kysely, MssqlDialect } from 'kysely';
+import { introspectMssql } from '@/dialects/mssql/introspect';
+
+const SKIP_MSSQL_TESTS = !process.env.TEST_MSSQL;
+
+describe.skipIf(SKIP_MSSQL_TESTS)('MSSQL Introspector', () => {
+  let db: Kysely<any>;
+
+  beforeAll(async () => {
+    const tarn = await import('tarn');
+    const tedious = await import('tedious');
+
+    db = new Kysely({
+      dialect: new MssqlDialect({
+        tarn: {
+          ...tarn,
+          options: { min: 0, max: 1 },
+        },
+        tedious: {
+          ...tedious,
+          connectionFactory: () => {
+            return new tedious.Connection({
+              authentication: {
+                options: { password: 'Test_Password123', userName: 'sa' },
+                type: 'default',
+              },
+              options: {
+                database: 'test_db',
+                encrypt: true,
+                port: 1434,
+                trustServerCertificate: true,
+              },
+              server: 'localhost',
+            });
+          },
+        },
+      }),
+    });
+  });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  test('should introspect tables from database', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    expect(metadata.tables.length).toBeGreaterThan(0);
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    expect(users).toBeDefined();
+    expect(users?.schema).toBe('dbo');
+  });
+
+  test('should introspect columns with correct types', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    expect(users).toBeDefined();
+
+    const idColumn = users?.columns.find((c) => c.name === 'id');
+    expect(idColumn).toBeDefined();
+    expect(idColumn?.dataType).toBe('int');
+    expect(idColumn?.isNullable).toBe(false);
+    expect(idColumn?.isAutoIncrement).toBe(true);
+
+    const emailColumn = users?.columns.find((c) => c.name === 'email');
+    expect(emailColumn).toBeDefined();
+    expect(emailColumn?.dataType).toBe('nvarchar');
+    expect(emailColumn?.isNullable).toBe(false);
+  });
+
+  test('should identify nullable columns', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    const updatedAtColumn = users?.columns.find((c) => c.name === 'updated_at');
+
+    expect(updatedAtColumn).toBeDefined();
+    expect(updatedAtColumn?.isNullable).toBe(true);
+  });
+
+  test('should identify identity columns', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    const idColumn = users?.columns.find((c) => c.name === 'id');
+
+    expect(idColumn?.isAutoIncrement).toBe(true);
+    expect(idColumn?.hasDefaultValue).toBe(true);
+  });
+
+  test('should introspect bit columns as bit type', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    const isActiveColumn = users?.columns.find((c) => c.name === 'is_active');
+
+    expect(isActiveColumn).toBeDefined();
+    expect(isActiveColumn?.dataType).toBe('bit');
+  });
+
+  test('should introspect binary columns', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    const files = metadata.tables.find((t) => t.name === 'files');
+    expect(files).toBeDefined();
+
+    const contentColumn = files?.columns.find((c) => c.name === 'content');
+    expect(contentColumn?.dataType).toBe('varbinary');
+
+    const checksumColumn = files?.columns.find((c) => c.name === 'checksum');
+    expect(checksumColumn?.dataType).toBe('binary');
+  });
+
+  test('should introspect uniqueidentifier columns', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    const files = metadata.tables.find((t) => t.name === 'files');
+    const guidColumn = files?.columns.find((c) => c.name === 'guid');
+
+    expect(guidColumn).toBeDefined();
+    expect(guidColumn?.dataType).toBe('uniqueidentifier');
+  });
+
+  test('should introspect various numeric types', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    const metrics = metadata.tables.find((t) => t.name === 'metrics');
+    expect(metrics).toBeDefined();
+
+    const tinyValColumn = metrics?.columns.find((c) => c.name === 'tiny_val');
+    expect(tinyValColumn?.dataType).toBe('tinyint');
+
+    const bigValColumn = metrics?.columns.find((c) => c.name === 'big_val');
+    expect(bigValColumn?.dataType).toBe('bigint');
+
+    const moneyValColumn = metrics?.columns.find((c) => c.name === 'money_val');
+    expect(moneyValColumn?.dataType).toBe('money');
+
+    const decimalValColumn = metrics?.columns.find((c) => c.name === 'decimal_val');
+    expect(decimalValColumn?.dataType).toBe('decimal');
+  });
+
+  test('should introspect date/time columns', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    const events = metadata.tables.find((t) => t.name === 'events');
+    expect(events).toBeDefined();
+
+    const dateColumn = events?.columns.find((c) => c.name === 'event_date');
+    expect(dateColumn?.dataType).toBe('date');
+
+    const datetime2Column = events?.columns.find((c) => c.name === 'event_datetime2');
+    expect(datetime2Column?.dataType).toBe('datetime2');
+
+    const datetimeoffsetColumn = events?.columns.find((c) => c.name === 'event_datetimeoffset');
+    expect(datetimeoffsetColumn?.dataType).toBe('datetimeoffset');
+  });
+
+  test('should introspect special types', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    const specialTypes = metadata.tables.find((t) => t.name === 'special_types');
+    expect(specialTypes).toBeDefined();
+
+    const xmlColumn = specialTypes?.columns.find((c) => c.name === 'xml_data');
+    expect(xmlColumn?.dataType).toBe('xml');
+
+    const variantColumn = specialTypes?.columns.find((c) => c.name === 'variant_data');
+    expect(variantColumn?.dataType).toBe('sql_variant');
+  });
+
+  test('should introspect views', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    const activeUsers = metadata.tables.find((t) => t.name === 'active_users');
+    expect(activeUsers).toBeDefined();
+    expect(activeUsers?.isView).toBe(true);
+    expect(activeUsers?.schema).toBe('dbo');
+
+    const columns = activeUsers?.columns ?? [];
+    expect(columns.length).toBe(4);
+
+    const idColumn = columns.find((c) => c.name === 'id');
+    expect(idColumn).toBeDefined();
+    expect(idColumn?.dataType).toBe('int');
+    expect(idColumn?.isAutoIncrement).toBe(false);
+  });
+
+  test('should introspect multiple schemas', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo', 'test_schema'] });
+
+    const tableSchemas = metadata.tables.map((t) => t.schema);
+    expect(tableSchemas).toContain('dbo');
+    expect(tableSchemas).toContain('test_schema');
+
+    const tasksTable = metadata.tables.find(
+      (t) => t.schema === 'test_schema' && t.name === 'tasks'
+    );
+    expect(tasksTable).toBeDefined();
+    expect(tasksTable?.columns.length).toBeGreaterThan(0);
+  });
+
+  test('should introspect views from different schemas', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo', 'test_schema'] });
+
+    const activeTasksView = metadata.tables.find(
+      (t) => t.schema === 'test_schema' && t.name === 'active_tasks'
+    );
+    expect(activeTasksView).toBeDefined();
+    expect(activeTasksView?.isView).toBe(true);
+  });
+
+  test('should return empty enums (MSSQL has no native enum)', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+    expect(metadata.enums).toEqual([]);
+  });
+
+  test('should detect columns with default values', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    const users = metadata.tables.find((t) => t.name === 'users');
+    const createdAtColumn = users?.columns.find((c) => c.name === 'created_at');
+
+    expect(createdAtColumn?.hasDefaultValue).toBe(true);
+  });
+
+  test('should detect computed columns as auto-increment (Generated)', async () => {
+    const metadata = await introspectMssql(db, { schemas: ['dbo'] });
+
+    const orders = metadata.tables.find((t) => t.name === 'orders');
+    expect(orders).toBeDefined();
+
+    const totalPriceColumn = orders?.columns.find((c) => c.name === 'total_price');
+    expect(totalPriceColumn).toBeDefined();
+    expect(totalPriceColumn?.isAutoIncrement).toBe(true);
+    expect(totalPriceColumn?.hasDefaultValue).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add Microsoft SQL Server support as the fourth database dialect
- Comprehensive implementation with 41 new tests
- Auto-initializing Docker container for integration tests

## Changes

### New Files
- `src/dialects/mssql/index.ts` - Dialect class with tedious + tarn connection
- `src/dialects/mssql/introspect.ts` - INFORMATION_SCHEMA queries
- `src/dialects/mssql/type-mapper.ts` - MSSQL to TypeScript type mappings
- `test/fixtures/mssql/` - Docker setup with auto-init

### Features
- Support both URL (`mssql://`) and ADO.NET connection string formats
- Introspect tables, views, identity columns, computed columns
- Default schema: `dbo`
- All MSSQL types mapped: `uniqueidentifier`, `datetime2`, `money`, `xml`, `varbinary`, etc.
- Computed columns marked as `Generated<T>`

### Test Coverage
| Category | Tests |
|----------|-------|
| Type Mapper | 16 |
| Connection String | 9 |
| Integration | 16 |
| **Total** | **41** |

## Usage

```sh
# Install
npm install kysely-gen kysely tedious tarn

# URL format
kysely-gen --url "mssql://user:pass@localhost:1433/db"

# ADO.NET format
kysely-gen --url "Server=localhost;Database=db;User Id=user;Password=pass"
```

## Test plan

- [x] All 279 tests pass (including 41 new MSSQL tests)
- [x] Build succeeds
- [x] README updated with MSSQL documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)