### PR TITLE
feat: wrap columns with DEFAULT values in Generated<T>

### DIFF
--- a/src/transform/table.ts
+++ b/src/transform/table.ts
@@ -56,7 +56,7 @@ export function transformColumn(
     });
   }
 
-  if (column.isAutoIncrement) {
+  if (column.isAutoIncrement || column.hasDefaultValue) {
     type = {
       kind: 'generic',
       name: 'Generated',

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -40,8 +40,8 @@ export interface Comment {
   post_id: number;
   user_id: number;
   content: string;
-  status: StatusEnum;
-  created_at: ColumnType<Date, Date | string, Date | string>;
+  status: Generated<StatusEnum>;
+  created_at: Generated<ColumnType<Date, Date | string, Date | string>>;
 }
 
 export interface Measurement {
@@ -57,18 +57,18 @@ export interface Post {
   title: string;
   content: string | null;
   published_at: ColumnType<Date, Date | string, Date | string> | null;
-  view_count: number;
+  view_count: Generated<number>;
 }
 
 export interface User {
   id: Generated<number>;
   email: string;
   username: string;
-  created_at: ColumnType<Date, Date | string, Date | string>;
+  created_at: Generated<ColumnType<Date, Date | string, Date | string>>;
   updated_at: ColumnType<Date, Date | string, Date | string> | null;
-  is_active: boolean;
+  is_active: Generated<boolean>;
   metadata: JsonValue | null;
-  tags: string[] | null;
+  tags: Generated<string[] | null>;
   scores: number[] | null;
 }
 

--- a/test/camelcase.test.ts
+++ b/test/camelcase.test.ts
@@ -72,7 +72,7 @@ describe('CamelCase Support', () => {
       expect(code).toContain('userId: Generated<number>');
       expect(code).toContain('firstName: string');
       expect(code).toContain('lastName: string');
-      expect(code).toContain('createdAt: ColumnType<Date, Date | string, Date | string>');
+      expect(code).toContain('createdAt: Generated<ColumnType<Date, Date | string, Date | string>>');
     });
 
     test('should convert table names in DB interface to camelCase', () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -50,7 +50,7 @@ describe('Integration: Full pipeline', () => {
 
     // Check non-nullable columns
     expect(output).toContain('email: string;');
-    expect(output).toContain('is_active: boolean;');
+    expect(output).toContain('is_active: Generated<boolean>');
 
     // Snapshot the entire output
     expect(output).toMatchSnapshot();

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -981,7 +981,7 @@ describe('Transform', () => {
       expect(longInterface).toBeDefined();
     });
 
-    test('should handle table with columns that have defaults but are not auto-increment', () => {
+    test('should wrap columns with defaults in Generated<T>', () => {
       const metadata: DatabaseMetadata = {
         tables: [
           {
@@ -1002,6 +1002,20 @@ describe('Transform', () => {
                 isAutoIncrement: false,
                 hasDefaultValue: true,
               },
+              {
+                name: 'is_active',
+                dataType: 'bool',
+                isNullable: false,
+                isAutoIncrement: false,
+                hasDefaultValue: true,
+              },
+              {
+                name: 'title',
+                dataType: 'varchar',
+                isNullable: false,
+                isAutoIncrement: false,
+                hasDefaultValue: false,
+              },
             ],
           },
         ],
@@ -1017,13 +1031,25 @@ describe('Transform', () => {
       expect(defaultInterface).toBeDefined();
       if (defaultInterface?.kind === 'interface') {
         const idProp = defaultInterface.properties.find((p) => p.name === 'id');
-        expect(idProp?.type.kind).not.toBe('generic');
+        expect(idProp?.type.kind).toBe('generic');
+        if (idProp?.type.kind === 'generic') {
+          expect(idProp.type.name).toBe('Generated');
+        }
 
         const createdProp = defaultInterface.properties.find((p) => p.name === 'created_at');
         expect(createdProp?.type.kind).toBe('generic');
         if (createdProp?.type.kind === 'generic') {
-          expect(createdProp.type.name).toBe('ColumnType');
+          expect(createdProp.type.name).toBe('Generated');
         }
+
+        const isActiveProp = defaultInterface.properties.find((p) => p.name === 'is_active');
+        expect(isActiveProp?.type.kind).toBe('generic');
+        if (isActiveProp?.type.kind === 'generic') {
+          expect(isActiveProp.type.name).toBe('Generated');
+        }
+
+        const titleProp = defaultInterface.properties.find((p) => p.name === 'title');
+        expect(titleProp?.type.kind).toBe('primitive');
       }
     });
   });


### PR DESCRIPTION
## Summary

- Columns with DEFAULT values are now wrapped with `Generated<T>` to make them optional on insert
- Previously only auto-increment columns were wrapped

Closes #25

## Test plan

- [x] Unit tests updated
- [x] Integration test updated
- [x] Snapshot updated


🤖 Generated with [Claude Code](https://claude.com/claude-code)