### PR TITLE
feat: parse SQLite CHECK constraints for enum and boolean generation

### DIFF
--- a/src/introspect/types.ts
+++ b/src/introspect/types.ts
@@ -4,7 +4,8 @@
 
 export type CheckConstraintValues =
   | { type: 'string'; values: string[] }
-  | { type: 'number'; values: number[] };
+  | { type: 'number'; values: number[] }
+  | { type: 'boolean' };
 
 export type ColumnMetadata = {
   name: string;

--- a/src/transform/table.ts
+++ b/src/transform/table.ts
@@ -51,16 +51,26 @@ export function transformColumn(
       };
     }
   } else if (column.checkConstraint) {
-    const literalTypes: TypeNode[] = column.checkConstraint.values.map((v) => ({
-      kind: 'literal' as const,
-      value: v,
-    }));
+    if (column.checkConstraint.type === 'boolean') {
+      type = { kind: 'primitive', value: 'boolean' };
+      if (column.isNullable) {
+        type = {
+          kind: 'union',
+          types: [type, { kind: 'primitive', value: 'null' }],
+        };
+      }
+    } else {
+      const literalTypes: TypeNode[] = column.checkConstraint.values.map((v) => ({
+        kind: 'literal' as const,
+        value: v,
+      }));
 
-    if (column.isNullable) {
-      literalTypes.push({ kind: 'primitive', value: 'null' });
+      if (column.isNullable) {
+        literalTypes.push({ kind: 'primitive', value: 'null' });
+      }
+
+      type = { kind: 'union', types: literalTypes };
     }
-
-    type = { kind: 'union', types: literalTypes };
   } else {
     type = mapType(column.dataType, {
       isNullable: column.isNullable,

--- a/src/utils/sqlite-ddl-parser.ts
+++ b/src/utils/sqlite-ddl-parser.ts
@@ -1,0 +1,22 @@
+export type SqliteCheckConstraint = {
+  columnName: string;
+  definition: string;
+};
+
+export function parseSqliteTableDDL(sql: string): SqliteCheckConstraint[] {
+  const constraints: SqliteCheckConstraint[] = [];
+
+  const checkRegex = /CHECK\s*\(\s*(\w+)\s+IN\s*\(([^)]+)\)\s*\)/gi;
+
+  let match;
+  while ((match = checkRegex.exec(sql)) !== null) {
+    const columnName = match[1];
+    const valuesPart = match[2];
+    constraints.push({
+      columnName,
+      definition: `${columnName} IN (${valuesPart})`,
+    });
+  }
+
+  return constraints;
+}

--- a/src/zod/transform.ts
+++ b/src/zod/transform.ts
@@ -85,7 +85,9 @@ function transformColumnToZod(
       schema = { kind: 'zod-modified', schema, modifiers };
     }
   } else if (column.checkConstraint) {
-    if (column.checkConstraint.type === 'string') {
+    if (column.checkConstraint.type === 'boolean') {
+      schema = { kind: 'zod-primitive', method: 'boolean' };
+    } else if (column.checkConstraint.type === 'string') {
       schema = { kind: 'zod-enum', values: column.checkConstraint.values };
     } else {
       schema = {

--- a/test/fixtures/sqlite-init.sql
+++ b/test/fixtures/sqlite-init.sql
@@ -52,6 +52,15 @@ CREATE TABLE metrics (
   blob_val BLOB
 );
 
+-- Table with boolean pattern CHECK constraints
+CREATE TABLE settings (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  is_enabled INTEGER NOT NULL CHECK(is_enabled IN (0, 1)),
+  is_public INTEGER CHECK(is_public IN (0, 1)),
+  priority INTEGER CHECK(priority IN (1, 2, 3, 4, 5))
+);
+
 -- Create a view
 CREATE VIEW active_users AS
 SELECT id, email, username, created_at

--- a/test/introspect/sqlite.test.ts
+++ b/test/introspect/sqlite.test.ts
@@ -218,4 +218,47 @@ describe('SQLite Introspector', () => {
     expect(userIdColumn?.isNullable).toBe(false);
     expect(userIdColumn?.isAutoIncrement).toBe(false);
   });
+
+  test('should introspect CHECK constraints with string values', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const posts = metadata.tables.find((t) => t.name === 'posts');
+    const statusColumn = posts?.columns.find((c) => c.name === 'status');
+
+    expect(statusColumn?.checkConstraint).toEqual({
+      type: 'string',
+      values: ['draft', 'published', 'archived'],
+    });
+  });
+
+  test('should introspect CHECK constraints with boolean pattern (0, 1)', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const settings = metadata.tables.find((t) => t.name === 'settings');
+    const isEnabledColumn = settings?.columns.find((c) => c.name === 'is_enabled');
+
+    expect(isEnabledColumn?.checkConstraint).toEqual({ type: 'boolean' });
+  });
+
+  test('should introspect nullable CHECK constraint with boolean pattern', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const settings = metadata.tables.find((t) => t.name === 'settings');
+    const isPublicColumn = settings?.columns.find((c) => c.name === 'is_public');
+
+    expect(isPublicColumn?.checkConstraint).toEqual({ type: 'boolean' });
+    expect(isPublicColumn?.isNullable).toBe(true);
+  });
+
+  test('should introspect CHECK constraints with numeric values', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+
+    const settings = metadata.tables.find((t) => t.name === 'settings');
+    const priorityColumn = settings?.columns.find((c) => c.name === 'priority');
+
+    expect(priorityColumn?.checkConstraint).toEqual({
+      type: 'number',
+      values: [1, 2, 3, 4, 5],
+    });
+  });
 });

--- a/test/utils/sqlite-ddl-parser.test.ts
+++ b/test/utils/sqlite-ddl-parser.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test';
+import { parseSqliteTableDDL } from '@/utils/sqlite-ddl-parser';
+
+describe('parseSqliteTableDDL', () => {
+  test('parses inline CHECK with string IN list', () => {
+    const ddl = `CREATE TABLE posts (
+      id INTEGER PRIMARY KEY,
+      status TEXT NOT NULL CHECK(status IN ('draft', 'published', 'archived'))
+    )`;
+    const result = parseSqliteTableDDL(ddl);
+    expect(result).toEqual([
+      { columnName: 'status', definition: "status IN ('draft', 'published', 'archived')" },
+    ]);
+  });
+
+  test('parses inline CHECK with numeric IN list', () => {
+    const ddl = `CREATE TABLE priorities (
+      id INTEGER PRIMARY KEY,
+      level INTEGER NOT NULL CHECK(level IN (1, 2, 3, 4, 5))
+    )`;
+    const result = parseSqliteTableDDL(ddl);
+    expect(result).toEqual([
+      { columnName: 'level', definition: 'level IN (1, 2, 3, 4, 5)' },
+    ]);
+  });
+
+  test('parses boolean pattern CHECK(col IN (0, 1))', () => {
+    const ddl = `CREATE TABLE settings (
+      id INTEGER PRIMARY KEY,
+      is_enabled INTEGER NOT NULL CHECK(is_enabled IN (0, 1))
+    )`;
+    const result = parseSqliteTableDDL(ddl);
+    expect(result).toEqual([
+      { columnName: 'is_enabled', definition: 'is_enabled IN (0, 1)' },
+    ]);
+  });
+
+  test('parses multiple CHECK constraints in one table', () => {
+    const ddl = `CREATE TABLE posts (
+      id INTEGER PRIMARY KEY,
+      status TEXT NOT NULL CHECK(status IN ('draft', 'published')),
+      is_featured INTEGER CHECK(is_featured IN (0, 1))
+    )`;
+    const result = parseSqliteTableDDL(ddl);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      columnName: 'status',
+      definition: "status IN ('draft', 'published')",
+    });
+    expect(result).toContainEqual({
+      columnName: 'is_featured',
+      definition: 'is_featured IN (0, 1)',
+    });
+  });
+
+  test('handles CHECK with spaces around parentheses', () => {
+    const ddl = `CREATE TABLE posts (
+      status TEXT CHECK ( status IN ( 'a' , 'b' ) )
+    )`;
+    const result = parseSqliteTableDDL(ddl);
+    expect(result).toHaveLength(1);
+    expect(result[0].columnName).toBe('status');
+  });
+
+  test('handles CHECK with lowercase keyword', () => {
+    const ddl = `CREATE TABLE posts (
+      status TEXT check(status in ('a', 'b'))
+    )`;
+    const result = parseSqliteTableDDL(ddl);
+    expect(result).toHaveLength(1);
+    expect(result[0].columnName).toBe('status');
+  });
+
+  test('returns empty array for table without CHECK constraints', () => {
+    const ddl = `CREATE TABLE users (
+      id INTEGER PRIMARY KEY,
+      name TEXT NOT NULL
+    )`;
+    const result = parseSqliteTableDDL(ddl);
+    expect(result).toEqual([]);
+  });
+
+  test('ignores non-IN CHECK constraints (range checks)', () => {
+    const ddl = `CREATE TABLE metrics (
+      id INTEGER PRIMARY KEY,
+      value INTEGER CHECK(value >= 0 AND value <= 100)
+    )`;
+    const result = parseSqliteTableDDL(ddl);
+    expect(result).toEqual([]);
+  });
+
+  test('handles escaped quotes in string values', () => {
+    const ddl = `CREATE TABLE items (
+      status TEXT CHECK(status IN ('it''s ok', 'normal'))
+    )`;
+    const result = parseSqliteTableDDL(ddl);
+    expect(result).toHaveLength(1);
+    expect(result[0].columnName).toBe('status');
+  });
+
+  test('handles table-level CHECK constraint', () => {
+    const ddl = `CREATE TABLE posts (
+      id INTEGER PRIMARY KEY,
+      status TEXT,
+      CHECK(status IN ('draft', 'published'))
+    )`;
+    const result = parseSqliteTableDDL(ddl);
+    expect(result).toEqual([
+      { columnName: 'status', definition: "status IN ('draft', 'published')" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Parse CHECK constraints from SQLite DDL via `sqlite_master.sql`
- Detect `CHECK(col IN (0, 1))` as boolean pattern for SQLite
- Generate TypeScript `boolean` type and Zod `z.boolean()` for boolean pattern
- Support string and numeric enum patterns in SQLite

## Implementation

1. **SQLite DDL Parser** (`src/utils/sqlite-ddl-parser.ts`): Extracts CHECK constraints from CREATE TABLE DDL
2. **Check Constraint Parser**: Extended with `parseSqliteCheckConstraint()` and boolean detection
3. **SQLite Introspector**: Queries `sqlite_master.sql` and attaches parsed constraints to columns
4. **Transform Layer**: Handles `{ type: 'boolean' }` constraint in both TypeScript and Zod transforms

## Example

```sql
CREATE TABLE settings (
  is_enabled INTEGER NOT NULL CHECK(is_enabled IN (0, 1)),
  status TEXT CHECK(status IN ('draft', 'published'))
);
```

Generates:

**TypeScript:**
```typescript
export interface Setting {
  isEnabled: Generated<boolean>;
  status: 'draft' | 'published' | null;
}
```

**Zod:**
```typescript
export const settingSchema = z.object({
  isEnabled: z.boolean(),
  status: z.enum(['draft', 'published']).nullable(),
});
```

## Test plan

- [x] Unit tests for SQLite DDL parser
- [x] Unit tests for SQLite check constraint parsing (string, number, boolean)
- [x] Integration tests for SQLite introspection
- [x] All 445 tests pass

Closes #31
Closes #33

🤖 Generated with [Claude Code](https://claude.ai/code)