### PR TITLE
feat: add Zod transform for SQLite/MSSQL boolean CHECK constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ npx kysely-gen --dialect mysql --url mysql://user:pass@localhost:3306/db
 | `--include-pattern <glob>` | Only include matching tables |
 | `--exclude-pattern <glob>` | Exclude matching tables |
 | `--zod` | Generate Zod schemas instead of TypeScript interfaces |
+| `--no-boolean-coerce` | Output `0 \| 1` instead of coercing to `boolean` for CHECK constraints |
 
 ## Zod Schema Generation
 
@@ -158,6 +159,21 @@ export interface DB {
 - Multi-schema support (default: `dbo`)
 - All MSSQL types: `uniqueidentifier`, `datetime2`, `datetimeoffset`, `money`, `xml`, `varbinary`, etc.
 - Both URL (`mssql://`) and ADO.NET connection string formats
+
+### Boolean Coercion (SQLite/MSSQL)
+
+SQLite and MSSQL store booleans as integers (0/1). When a `CHECK(col IN (0, 1))` constraint is detected, kysely-gen generates:
+
+**TypeScript:** `boolean`
+**Zod:** `z.union([z.literal(0), z.literal(1)]).transform(v => v === 1)`
+
+The Zod transform coerces the raw 0/1 from the database to `true`/`false`, ensuring runtime validation passes.
+
+Use `--no-boolean-coerce` to output raw `0 | 1` instead:
+
+```sh
+kysely-gen --zod --no-boolean-coerce
+```
 
 ## Type Mappings
 

--- a/src/transform/table.ts
+++ b/src/transform/table.ts
@@ -52,7 +52,17 @@ export function transformColumn(
     }
   } else if (column.checkConstraint) {
     if (column.checkConstraint.type === 'boolean') {
-      type = { kind: 'primitive', value: 'boolean' };
+      if (options?.noBooleanCoerce) {
+        type = {
+          kind: 'union',
+          types: [
+            { kind: 'literal', value: 0 },
+            { kind: 'literal', value: 1 },
+          ],
+        };
+      } else {
+        type = { kind: 'primitive', value: 'boolean' };
+      }
       if (column.isNullable) {
         type = {
           kind: 'union',

--- a/src/transform/types.ts
+++ b/src/transform/types.ts
@@ -12,6 +12,7 @@ export type TransformOptions = {
   excludePattern?: string[];
   dialectName?: DialectName;
   mapType?: TypeMapper;
+  noBooleanCoerce?: boolean;
 };
 
 export type TransformWarning = {

--- a/src/zod/nodes.ts
+++ b/src/zod/nodes.ts
@@ -44,6 +44,12 @@ export type ZodCustomNode = {
   typeReference: string;
 };
 
+export type ZodTransformNode = {
+  kind: 'zod-transform';
+  schema: ZodSchemaNode;
+  transformFn: string;
+};
+
 export type ZodPropertyNode = {
   name: string;
   schema: ZodSchemaNode;
@@ -58,7 +64,8 @@ export type ZodSchemaNode =
   | ZodObjectNode
   | ZodModifiedNode
   | ZodReferenceNode
-  | ZodCustomNode;
+  | ZodCustomNode
+  | ZodTransformNode;
 
 export type ZodSchemaDeclaration = {
   kind: 'zod-schema-declaration';

--- a/src/zod/serialize.ts
+++ b/src/zod/serialize.ts
@@ -13,6 +13,7 @@ import type {
   ZodReferenceNode,
   ZodSchemaDeclaration,
   ZodSchemaNode,
+  ZodTransformNode,
   ZodUnionNode,
 } from './nodes';
 
@@ -66,6 +67,8 @@ export function serializeZodSchema(node: ZodSchemaNode): string {
       return serializeZodReference(node);
     case 'zod-custom':
       return serializeZodCustom(node);
+    case 'zod-transform':
+      return serializeZodTransform(node);
   }
 }
 
@@ -121,6 +124,10 @@ function serializeZodReference(node: ZodReferenceNode): string {
 
 function serializeZodCustom(node: ZodCustomNode): string {
   return `z.custom<${node.typeReference}>()`;
+}
+
+function serializeZodTransform(node: ZodTransformNode): string {
+  return `${serializeZodSchema(node.schema)}.transform(${node.transformFn})`;
 }
 
 function serializeZodDeclaration(node: ZodDeclarationNode): string {

--- a/src/zod/transform.ts
+++ b/src/zod/transform.ts
@@ -14,6 +14,7 @@ import { EnumNameResolver } from '@/transform/enum';
 
 export type ZodTransformOptions = {
   camelCase?: boolean;
+  noBooleanCoerce?: boolean;
 };
 
 function uncapitalize(str: string): string {
@@ -86,7 +87,23 @@ function transformColumnToZod(
     }
   } else if (column.checkConstraint) {
     if (column.checkConstraint.type === 'boolean') {
-      schema = { kind: 'zod-primitive', method: 'boolean' };
+      const unionSchema: ZodSchemaNode = {
+        kind: 'zod-union',
+        schemas: [
+          { kind: 'zod-literal', value: 0 },
+          { kind: 'zod-literal', value: 1 },
+        ],
+      };
+
+      if (options?.noBooleanCoerce) {
+        schema = unionSchema;
+      } else {
+        schema = {
+          kind: 'zod-transform',
+          schema: unionSchema,
+          transformFn: 'v => v === 1',
+        };
+      }
     } else if (column.checkConstraint.type === 'string') {
       schema = { kind: 'zod-enum', values: column.checkConstraint.values };
     } else {

--- a/test/introspect/sqlite.test.ts
+++ b/test/introspect/sqlite.test.ts
@@ -276,12 +276,21 @@ describe('SQLite Introspector', () => {
     expect(output).toContain("'archived'");
   });
 
-  test('e2e: CHECK constraints with boolean pattern should generate z.boolean()', async () => {
+  test('e2e: CHECK constraints with boolean pattern should generate transform to boolean', async () => {
     const metadata = await introspectSqlite(db, { schemas: ['main'] });
     const zodProgram = transformDatabaseToZod(metadata);
     const output = serializeZod(zodProgram);
 
-    expect(output).toContain('z.boolean()');
+    expect(output).toContain('z.union([z.literal(0), z.literal(1)]).transform(v => v === 1)');
+  });
+
+  test('e2e: CHECK constraints with boolean pattern and noBooleanCoerce should generate union', async () => {
+    const metadata = await introspectSqlite(db, { schemas: ['main'] });
+    const zodProgram = transformDatabaseToZod(metadata, { noBooleanCoerce: true });
+    const output = serializeZod(zodProgram);
+
+    expect(output).toContain('z.union([z.literal(0), z.literal(1)])');
+    expect(output).not.toContain('.transform(v => v === 1)');
   });
 
   test('e2e: CHECK constraints with numeric values should generate z.union of z.literal', async () => {

--- a/test/zod/serialize.test.ts
+++ b/test/zod/serialize.test.ts
@@ -97,6 +97,38 @@ describe('Zod Serializer', () => {
     test('should serialize custom types', () => {
       expect(serializeZodSchema({ kind: 'zod-custom', typeReference: 'Buffer' })).toBe('z.custom<Buffer>()');
     });
+
+    test('should serialize transform', () => {
+      expect(serializeZodSchema({
+        kind: 'zod-transform',
+        schema: {
+          kind: 'zod-union',
+          schemas: [
+            { kind: 'zod-literal', value: 0 },
+            { kind: 'zod-literal', value: 1 },
+          ],
+        },
+        transformFn: 'v => v === 1',
+      })).toBe('z.union([z.literal(0), z.literal(1)]).transform(v => v === 1)');
+    });
+
+    test('should serialize transform with modifiers', () => {
+      expect(serializeZodSchema({
+        kind: 'zod-modified',
+        schema: {
+          kind: 'zod-transform',
+          schema: {
+            kind: 'zod-union',
+            schemas: [
+              { kind: 'zod-literal', value: 0 },
+              { kind: 'zod-literal', value: 1 },
+            ],
+          },
+          transformFn: 'v => v === 1',
+        },
+        modifiers: ['nullable'],
+      })).toBe('z.union([z.literal(0), z.literal(1)]).transform(v => v === 1).nullable()');
+    });
   });
 
   describe('serializeZod (full program)', () => {


### PR DESCRIPTION
## Summary

- SQLite/MSSQL store booleans as integers (0/1), but z.boolean() expects true/false
- Now generates `z.union([z.literal(0), z.literal(1)]).transform(v => v === 1)` for boolean CHECK constraints
- Added `--no-boolean-coerce` flag to output raw `0 | 1` instead

## Test plan

- [x] Run `bun test` - all tests pass
- [x] Verify Zod output includes `.transform(v => v === 1)`
- [x] Verify TypeScript output is `boolean`
- [x] Test with `--no-boolean-coerce` flag

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/code)