### PR TITLE
fix: remove table name singularization

### DIFF
--- a/src/transform/table.ts
+++ b/src/transform/table.ts
@@ -2,7 +2,7 @@ import type { InterfaceNode, PropertyNode, TypeNode } from '@/ast/nodes';
 import type { ColumnMetadata, EnumMetadata, TableMetadata } from '@/introspect/types';
 import { toCamelCase } from '@/utils/case-converter';
 import type { TransformOptions, TypeMapper } from '@/transform/types';
-import { toPascalCase, singularize } from '@/transform/utils';
+import { toPascalCase } from '@/transform/utils';
 import type { EnumNameResolver } from '@/transform/enum';
 
 export function transformTable(
@@ -20,7 +20,7 @@ export function transformTable(
 
   return {
     kind: 'interface',
-    name: toPascalCase(singularize(table.name)),
+    name: toPascalCase(table.name),
     properties,
     exported: true,
   };
@@ -115,7 +115,7 @@ export function createDBInterface(tables: TableMetadata[], options?: TransformOp
       name: tableName,
       type: {
         kind: 'reference',
-        name: toPascalCase(singularize(table.name)),
+        name: toPascalCase(table.name),
       },
       optional: false,
     };

--- a/src/transform/utils.ts
+++ b/src/transform/utils.ts
@@ -4,10 +4,3 @@ export function toPascalCase(str: string): string {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join('');
 }
-
-export function singularize(str: string): string {
-  if (str.endsWith('s')) {
-    return str.slice(0, -1);
-  }
-  return str;
-}

--- a/src/zod/transform.ts
+++ b/src/zod/transform.ts
@@ -9,7 +9,7 @@ import type {
 } from './nodes';
 import { mapPostgresTypeToZod } from './type-mapper';
 import { toCamelCase } from '@/utils/case-converter';
-import { toPascalCase, singularize } from '@/transform/utils';
+import { toPascalCase } from '@/transform/utils';
 import { EnumNameResolver } from '@/transform/enum';
 
 export type ZodTransformOptions = {
@@ -132,7 +132,7 @@ function transformTableToZod(
   mode: 'select' | 'insert' | 'update',
   options?: ZodTransformOptions
 ): ZodSchemaDeclaration {
-  const baseName = toPascalCase(singularize(table.name));
+  const baseName = toPascalCase(table.name);
   const schemaName = getSchemaName(baseName, mode);
 
   const properties = table.columns.map((col) =>
@@ -170,7 +170,7 @@ export function transformDatabaseToZod(
   }
 
   for (const table of metadata.tables) {
-    const baseName = toPascalCase(singularize(table.name));
+    const baseName = toPascalCase(table.name);
 
     declarations.push(transformTableToZod(table, metadata.enums, enumResolver, 'select', options));
     declarations.push(transformTableToZod(table, metadata.enums, enumResolver, 'insert', options));

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -41,7 +41,7 @@ export interface CheckConstraintsTest {
   regex_col: string | null;
 }
 
-export interface Comment {
+export interface Comments {
   id: Generated<number>;
   post_id: number;
   user_id: number;
@@ -55,14 +55,14 @@ export interface DomainCheckTest {
   status: 'draft' | 'published' | 'archived';
 }
 
-export interface Measurement {
+export interface Measurements {
   id: Generated<number>;
   measure_date: Timestamp;
   value: Numeric;
   sensor_id: number;
 }
 
-export interface Post {
+export interface Posts {
   id: Generated<number>;
   user_id: number;
   title: string;
@@ -71,7 +71,7 @@ export interface Post {
   view_count: Generated<number>;
 }
 
-export interface User {
+export interface Users {
   id: Generated<number>;
   email: string;
   username: string;
@@ -83,14 +83,14 @@ export interface User {
   scores: number[] | null;
 }
 
-export interface ActiveUser {
+export interface ActiveUsers {
   id: number | null;
   email: string | null;
   username: string | null;
   created_at: Timestamp | null;
 }
 
-export interface UserStat {
+export interface UserStats {
   id: number | null;
   username: string | null;
   post_count: Int8 | null;
@@ -105,13 +105,13 @@ export interface UserTagsView {
 
 export interface DB {
   check_constraints_test: CheckConstraintsTest;
-  comments: Comment;
+  comments: Comments;
   domain_check_test: DomainCheckTest;
-  measurements: Measurement;
-  posts: Post;
-  users: User;
-  active_users: ActiveUser;
-  user_stats: UserStat;
+  measurements: Measurements;
+  posts: Posts;
+  users: Users;
+  active_users: ActiveUsers;
+  user_stats: UserStats;
   user_tags_view: UserTagsView;
 }
 "
@@ -158,7 +158,7 @@ export type NewCheckConstraintsTest = z.infer<typeof newCheckConstraintsTestSche
 
 export type CheckConstraintsTestUpdate = z.infer<typeof checkConstraintsTestUpdateSchema>;
 
-export const commentSchema = z.object({
+export const commentsSchema = z.object({
   id: z.number(),
   post_id: z.number(),
   user_id: z.number(),
@@ -167,7 +167,7 @@ export const commentSchema = z.object({
   created_at: z.date(),
 });
 
-export const newCommentSchema = z.object({
+export const newCommentsSchema = z.object({
   id: z.number().optional(),
   post_id: z.number(),
   user_id: z.number(),
@@ -176,7 +176,7 @@ export const newCommentSchema = z.object({
   created_at: z.union([z.date(), z.string()]).optional(),
 });
 
-export const commentUpdateSchema = z.object({
+export const commentsUpdateSchema = z.object({
   id: z.number().optional(),
   post_id: z.number().optional(),
   user_id: z.number().optional(),
@@ -185,11 +185,11 @@ export const commentUpdateSchema = z.object({
   created_at: z.union([z.date(), z.string()]).optional(),
 });
 
-export type Comment = z.infer<typeof commentSchema>;
+export type Comments = z.infer<typeof commentsSchema>;
 
-export type NewComment = z.infer<typeof newCommentSchema>;
+export type NewComments = z.infer<typeof newCommentsSchema>;
 
-export type CommentUpdate = z.infer<typeof commentUpdateSchema>;
+export type CommentsUpdate = z.infer<typeof commentsUpdateSchema>;
 
 export const domainCheckTestSchema = z.object({
   id: z.number(),
@@ -212,32 +212,32 @@ export type NewDomainCheckTest = z.infer<typeof newDomainCheckTestSchema>;
 
 export type DomainCheckTestUpdate = z.infer<typeof domainCheckTestUpdateSchema>;
 
-export const measurementSchema = z.object({
+export const measurementsSchema = z.object({
   id: z.number(),
   measure_date: z.date(),
   value: z.string(),
   sensor_id: z.number(),
 });
 
-export const newMeasurementSchema = z.object({
+export const newMeasurementsSchema = z.object({
   id: z.number().optional(),
   measure_date: z.union([z.date(), z.string()]),
   value: z.union([z.string(), z.number()]),
   sensor_id: z.number(),
 });
 
-export const measurementUpdateSchema = z.object({
+export const measurementsUpdateSchema = z.object({
   id: z.number().optional(),
   measure_date: z.union([z.date(), z.string()]).optional(),
   value: z.union([z.string(), z.number()]).optional(),
   sensor_id: z.number().optional(),
 });
 
-export type Measurement = z.infer<typeof measurementSchema>;
+export type Measurements = z.infer<typeof measurementsSchema>;
 
-export type NewMeasurement = z.infer<typeof newMeasurementSchema>;
+export type NewMeasurements = z.infer<typeof newMeasurementsSchema>;
 
-export type MeasurementUpdate = z.infer<typeof measurementUpdateSchema>;
+export type MeasurementsUpdate = z.infer<typeof measurementsUpdateSchema>;
 
 export const measurements2024Q1Schema = z.object({
   id: z.number(),
@@ -293,7 +293,7 @@ export type NewMeasurements2024Q2 = z.infer<typeof newMeasurements2024Q2Schema>;
 
 export type Measurements2024Q2Update = z.infer<typeof measurements2024Q2UpdateSchema>;
 
-export const postSchema = z.object({
+export const postsSchema = z.object({
   id: z.number(),
   user_id: z.number(),
   title: z.string(),
@@ -302,7 +302,7 @@ export const postSchema = z.object({
   view_count: z.number(),
 });
 
-export const newPostSchema = z.object({
+export const newPostsSchema = z.object({
   id: z.number().optional(),
   user_id: z.number(),
   title: z.string(),
@@ -311,7 +311,7 @@ export const newPostSchema = z.object({
   view_count: z.number().optional(),
 });
 
-export const postUpdateSchema = z.object({
+export const postsUpdateSchema = z.object({
   id: z.number().optional(),
   user_id: z.number().optional(),
   title: z.string().optional(),
@@ -320,13 +320,13 @@ export const postUpdateSchema = z.object({
   view_count: z.number().optional(),
 });
 
-export type Post = z.infer<typeof postSchema>;
+export type Posts = z.infer<typeof postsSchema>;
 
-export type NewPost = z.infer<typeof newPostSchema>;
+export type NewPosts = z.infer<typeof newPostsSchema>;
 
-export type PostUpdate = z.infer<typeof postUpdateSchema>;
+export type PostsUpdate = z.infer<typeof postsUpdateSchema>;
 
-export const userSchema = z.object({
+export const usersSchema = z.object({
   id: z.number(),
   email: z.string(),
   username: z.string(),
@@ -338,7 +338,7 @@ export const userSchema = z.object({
   scores: z.array(z.number()).nullable(),
 });
 
-export const newUserSchema = z.object({
+export const newUsersSchema = z.object({
   id: z.number().optional(),
   email: z.string(),
   username: z.string(),
@@ -350,7 +350,7 @@ export const newUserSchema = z.object({
   scores: z.array(z.number()).nullable(),
 });
 
-export const userUpdateSchema = z.object({
+export const usersUpdateSchema = z.object({
   id: z.number().optional(),
   email: z.string().optional(),
   username: z.string().optional(),
@@ -362,65 +362,65 @@ export const userUpdateSchema = z.object({
   scores: z.array(z.number()).nullable().optional(),
 });
 
-export type User = z.infer<typeof userSchema>;
+export type Users = z.infer<typeof usersSchema>;
 
-export type NewUser = z.infer<typeof newUserSchema>;
+export type NewUsers = z.infer<typeof newUsersSchema>;
 
-export type UserUpdate = z.infer<typeof userUpdateSchema>;
+export type UsersUpdate = z.infer<typeof usersUpdateSchema>;
 
-export const activeUserSchema = z.object({
+export const activeUsersSchema = z.object({
   id: z.number().nullable(),
   email: z.string().nullable(),
   username: z.string().nullable(),
   created_at: z.date().nullable(),
 });
 
-export const newActiveUserSchema = z.object({
+export const newActiveUsersSchema = z.object({
   id: z.number().nullable(),
   email: z.string().nullable(),
   username: z.string().nullable(),
   created_at: z.union([z.date(), z.string()]).nullable(),
 });
 
-export const activeUserUpdateSchema = z.object({
+export const activeUsersUpdateSchema = z.object({
   id: z.number().nullable().optional(),
   email: z.string().nullable().optional(),
   username: z.string().nullable().optional(),
   created_at: z.union([z.date(), z.string()]).nullable().optional(),
 });
 
-export type ActiveUser = z.infer<typeof activeUserSchema>;
+export type ActiveUsers = z.infer<typeof activeUsersSchema>;
 
-export type NewActiveUser = z.infer<typeof newActiveUserSchema>;
+export type NewActiveUsers = z.infer<typeof newActiveUsersSchema>;
 
-export type ActiveUserUpdate = z.infer<typeof activeUserUpdateSchema>;
+export type ActiveUsersUpdate = z.infer<typeof activeUsersUpdateSchema>;
 
-export const userStatSchema = z.object({
+export const userStatsSchema = z.object({
   id: z.number().nullable(),
   username: z.string().nullable(),
   post_count: z.string().nullable(),
   comment_count: z.string().nullable(),
 });
 
-export const newUserStatSchema = z.object({
+export const newUserStatsSchema = z.object({
   id: z.number().nullable(),
   username: z.string().nullable(),
   post_count: z.union([z.string(), z.number(), z.bigint()]).nullable(),
   comment_count: z.union([z.string(), z.number(), z.bigint()]).nullable(),
 });
 
-export const userStatUpdateSchema = z.object({
+export const userStatsUpdateSchema = z.object({
   id: z.number().nullable().optional(),
   username: z.string().nullable().optional(),
   post_count: z.union([z.string(), z.number(), z.bigint()]).nullable().optional(),
   comment_count: z.union([z.string(), z.number(), z.bigint()]).nullable().optional(),
 });
 
-export type UserStat = z.infer<typeof userStatSchema>;
+export type UserStats = z.infer<typeof userStatsSchema>;
 
-export type NewUserStat = z.infer<typeof newUserStatSchema>;
+export type NewUserStats = z.infer<typeof newUserStatsSchema>;
 
-export type UserStatUpdate = z.infer<typeof userStatUpdateSchema>;
+export type UserStatsUpdate = z.infer<typeof userStatsUpdateSchema>;
 
 export const userTagsViewSchema = z.object({
   id: z.number().nullable(),

--- a/test/camelcase.test.ts
+++ b/test/camelcase.test.ts
@@ -79,14 +79,14 @@ describe('CamelCase Support', () => {
       const { program } = transformDatabase(metadata, { camelCase: true });
       const code = serialize(program);
 
-      expect(code).toContain('userProfiles: UserProfile');
+      expect(code).toContain('userProfiles: UserProfiles');
     });
 
     test('should keep interface names as PascalCase', () => {
       const { program } = transformDatabase(metadata, { camelCase: true });
       const code = serialize(program);
 
-      expect(code).toContain('export interface UserProfile {');
+      expect(code).toContain('export interface UserProfiles {');
     });
 
     test('should not convert names when camelCase is false', () => {
@@ -95,7 +95,7 @@ describe('CamelCase Support', () => {
 
       expect(code).toContain('user_id: Generated<number>');
       expect(code).toContain('first_name: string');
-      expect(code).toContain('user_profiles: UserProfile');
+      expect(code).toContain('user_profiles: UserProfiles');
     });
 
     test('should not convert names when camelCase is undefined', () => {
@@ -104,7 +104,7 @@ describe('CamelCase Support', () => {
 
       expect(code).toContain('user_id: Generated<number>');
       expect(code).toContain('first_name: string');
-      expect(code).toContain('user_profiles: UserProfile');
+      expect(code).toContain('user_profiles: UserProfiles');
     });
 
     test('should work with enum columns', () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -21,7 +21,7 @@ describe('CLI', () => {
 
       expect(stdout).toContain("import type { ColumnType } from 'kysely'");
       expect(stdout).toContain('export type Generated<T>');
-      expect(stdout).toContain('export interface User {');
+      expect(stdout).toContain('export interface Users {');
       expect(stdout).toContain('export interface DB {');
     });
 
@@ -181,9 +181,9 @@ describe('CLI', () => {
       await proc.exited;
 
       expect(stdout).toContain("import { z } from 'zod';");
-      expect(stdout).toContain('export const userSchema = z.object({');
-      expect(stdout).toContain('export const newUserSchema = z.object({');
-      expect(stdout).toContain('export type User = z.infer<typeof userSchema>;');
+      expect(stdout).toContain('export const usersSchema = z.object({');
+      expect(stdout).toContain('export const newUsersSchema = z.object({');
+      expect(stdout).toContain('export type Users = z.infer<typeof usersSchema>;');
     });
 
     test('should show Zod schemas generated message', async () => {
@@ -223,7 +223,7 @@ describe('CLI', () => {
 
       const content = await Bun.file(testOutputPath).text();
       expect(content).toContain("import { z } from 'zod';");
-      expect(content).toContain('export const userSchema = z.object({');
+      expect(content).toContain('export const usersSchema = z.object({');
 
       await unlink(testOutputPath);
     });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -36,9 +36,9 @@ describe('Integration: Full pipeline', () => {
     // Basic sanity checks
     expect(output).toContain("import type { ColumnType } from 'kysely'");
     expect(output).toContain('export type Generated<T>');
-    expect(output).toContain('export interface User {');
-    expect(output).toContain('export interface Post {');
-    expect(output).toContain('export interface Comment {');
+    expect(output).toContain('export interface Users {');
+    expect(output).toContain('export interface Posts {');
+    expect(output).toContain('export interface Comments {');
     expect(output).toContain('export interface DB {');
     expect(output).toContain('export type StatusEnum');
 
@@ -87,13 +87,13 @@ describe('Integration: Full pipeline', () => {
 
     expect(output).toContain("import { z } from 'zod';");
 
-    expect(output).toContain('export const userSchema = z.object({');
-    expect(output).toContain('export const newUserSchema = z.object({');
-    expect(output).toContain('export const userUpdateSchema = z.object({');
+    expect(output).toContain('export const usersSchema = z.object({');
+    expect(output).toContain('export const newUsersSchema = z.object({');
+    expect(output).toContain('export const usersUpdateSchema = z.object({');
 
-    expect(output).toContain('export type User = z.infer<typeof userSchema>;');
-    expect(output).toContain('export type NewUser = z.infer<typeof newUserSchema>;');
-    expect(output).toContain('export type UserUpdate = z.infer<typeof userUpdateSchema>;');
+    expect(output).toContain('export type Users = z.infer<typeof usersSchema>;');
+    expect(output).toContain('export type NewUsers = z.infer<typeof newUsersSchema>;');
+    expect(output).toContain('export type UsersUpdate = z.infer<typeof usersUpdateSchema>;');
 
     expect(output).toContain('export const statusEnumSchema = z.enum([');
 
@@ -134,7 +134,7 @@ describe('Integration: Full pipeline', () => {
         tags: ['tag1', 'tag2'],
         scores: null,
       };
-      const parsedUser = schemas.userSchema.parse(validUser);
+      const parsedUser = schemas.usersSchema.parse(validUser);
       expect(parsedUser.id).toBe(1);
       expect(parsedUser.email).toBe('test@example.com');
 
@@ -146,14 +146,14 @@ describe('Integration: Full pipeline', () => {
         tags: [],
         scores: null,
       };
-      const parsedNewUser = schemas.newUserSchema.parse(validNewUser);
+      const parsedNewUser = schemas.newUsersSchema.parse(validNewUser);
       expect(parsedNewUser.email).toBe('new@example.com');
 
       const validUpdate = { username: 'updated' };
-      const parsedUpdate = schemas.userUpdateSchema.parse(validUpdate);
+      const parsedUpdate = schemas.usersUpdateSchema.parse(validUpdate);
       expect(parsedUpdate.username).toBe('updated');
 
-      expect(() => schemas.userSchema.parse({ id: 'not a number' })).toThrow();
+      expect(() => schemas.usersSchema.parse({ id: 'not a number' })).toThrow();
 
     } finally {
       await unlink(tempFile).catch(() => {});

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -89,9 +89,9 @@ describe('Transform', () => {
         expect(generatedType.name).toBe('Generated<T>');
       }
 
-      // Check User interface
+      // Check Users interface
       const userInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'User'
+        (d) => d.kind === 'interface' && d.name === 'Users'
       );
       expect(userInterface).toBeDefined();
       if (userInterface?.kind === 'interface') {
@@ -116,7 +116,7 @@ describe('Transform', () => {
       if (dbInterface?.kind === 'interface') {
         expect(dbInterface.properties).toHaveLength(1);
         expect(dbInterface.properties[0]?.name).toBe('users');
-        expect(dbInterface.properties[0]?.type).toEqual({ kind: 'reference', name: 'User' });
+        expect(dbInterface.properties[0]?.type).toEqual({ kind: 'reference', name: 'Users' });
       }
     });
 
@@ -172,7 +172,7 @@ describe('Transform', () => {
       const { program } = transformDatabase(metadata);
 
       const postInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'Post'
+        (d) => d.kind === 'interface' && d.name === 'Posts'
       );
       if (postInterface?.kind === 'interface') {
         const contentProp = postInterface.properties.find((p) => p.name === 'content');
@@ -219,7 +219,7 @@ describe('Transform', () => {
       const { program } = transformDatabase(metadata);
 
       const commentInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'Comment'
+        (d) => d.kind === 'interface' && d.name === 'Comments'
       );
 
       expect(commentInterface).toBeDefined();
@@ -259,7 +259,7 @@ describe('Transform', () => {
       const { program } = transformDatabase(metadata);
 
       const commentInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'Comment'
+        (d) => d.kind === 'interface' && d.name === 'Comments'
       );
 
       if (commentInterface?.kind === 'interface') {
@@ -318,7 +318,7 @@ describe('Transform', () => {
         (d) => d.kind === 'interface' && d.name !== 'DB' && d.name !== 'IPostgresInterval'
       );
       expect(tableInterfaces).toHaveLength(1);
-      expect(tableInterfaces[0]?.name).toBe('User');
+      expect(tableInterfaces[0]?.name).toBe('Users');
     });
 
     test('should exclude matching tables with exclude pattern', () => {
@@ -332,10 +332,10 @@ describe('Transform', () => {
       expect(tableInterfaces).toHaveLength(3);
 
       const names = tableInterfaces.map((i) => i.name);
-      expect(names).toContain('User');
-      expect(names).toContain('Post');
-      expect(names).toContain('Session');
-      expect(names).not.toContain('InternalLog');
+      expect(names).toContain('Users');
+      expect(names).toContain('Posts');
+      expect(names).toContain('Sessions');
+      expect(names).not.toContain('InternalLogs');
     });
 
     test('should handle multiple include patterns', () => {
@@ -349,8 +349,8 @@ describe('Transform', () => {
       expect(tableInterfaces).toHaveLength(2);
 
       const names = tableInterfaces.map((i) => i.name);
-      expect(names).toContain('User');
-      expect(names).toContain('Session');
+      expect(names).toContain('Users');
+      expect(names).toContain('Sessions');
     });
 
     test('should combine include and exclude patterns', () => {
@@ -365,9 +365,9 @@ describe('Transform', () => {
       expect(tableInterfaces).toHaveLength(2);
 
       const names = tableInterfaces.map((i) => i.name);
-      expect(names).toContain('User');
-      expect(names).toContain('Post');
-      expect(names).not.toContain('InternalLog');
+      expect(names).toContain('Users');
+      expect(names).toContain('Posts');
+      expect(names).not.toContain('InternalLogs');
     });
 
     test('should update DB interface with filtered tables only', () => {
@@ -487,7 +487,7 @@ describe('Transform', () => {
       const { program } = transformDatabase(metadata);
 
       const productInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'Product'
+        (d) => d.kind === 'interface' && d.name === 'Products'
       );
 
       expect(productInterface).toBeDefined();
@@ -646,7 +646,7 @@ describe('Transform', () => {
       const { program } = transformDatabase(metadata);
 
       const complexInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'ComplexType'
+        (d) => d.kind === 'interface' && d.name === 'ComplexTypes'
       );
 
       expect(complexInterface).toBeDefined();
@@ -755,7 +755,7 @@ describe('Transform', () => {
       const { program } = transformDatabase(metadata);
 
       const typeInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'Type'
+        (d) => d.kind === 'interface' && d.name === 'Types'
       );
 
       expect(typeInterface).toBeDefined();
@@ -988,7 +988,7 @@ describe('Transform', () => {
       const { program } = transformDatabase(metadata);
 
       const defaultInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'Default'
+        (d) => d.kind === 'interface' && d.name === 'Defaults'
       );
 
       expect(defaultInterface).toBeDefined();
@@ -1094,7 +1094,7 @@ describe('Transform', () => {
       const { program } = transformDatabase(metadata);
 
       const configInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'Config'
+        (d) => d.kind === 'interface' && d.name === 'Configs'
       );
       expect(configInterface).toBeDefined();
       if (configInterface?.kind === 'interface') {
@@ -1126,7 +1126,7 @@ describe('Transform', () => {
       const { program } = transformDatabase(metadata);
 
       const eventInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'Event'
+        (d) => d.kind === 'interface' && d.name === 'Events'
       );
       if (eventInterface?.kind === 'interface') {
         const metadataProp = eventInterface.properties.find((p) => p.name === 'metadata');
@@ -1209,7 +1209,7 @@ describe('Transform', () => {
       const { program } = transformDatabase(metadata);
 
       const eventInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'Event'
+        (d) => d.kind === 'interface' && d.name === 'Events'
       );
       expect(eventInterface).toBeDefined();
       if (eventInterface?.kind === 'interface') {
@@ -1322,7 +1322,7 @@ describe('Transform', () => {
       const { program } = transformDatabase(metadata);
 
       const userInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'User'
+        (d) => d.kind === 'interface' && d.name === 'Users'
       );
       expect(userInterface).toBeDefined();
       if (userInterface?.kind === 'interface') {
@@ -1411,7 +1411,7 @@ describe('Transform', () => {
       const { program } = transformDatabase(metadata);
 
       const logInterface = program.declarations.find(
-        (d) => d.kind === 'interface' && d.name === 'Log'
+        (d) => d.kind === 'interface' && d.name === 'Logs'
       );
       expect(logInterface).toBeDefined();
       if (logInterface?.kind === 'interface') {

--- a/test/zod/transform.test.ts
+++ b/test/zod/transform.test.ts
@@ -41,7 +41,7 @@ describe('transformDatabaseToZod', () => {
     const program = transformDatabaseToZod(metadata);
 
     const selectSchema = program.declarations.find(
-      (d) => d.kind === 'zod-schema-declaration' && d.name === 'userSchema'
+      (d) => d.kind === 'zod-schema-declaration' && d.name === 'usersSchema'
     );
     expect(selectSchema).toBeDefined();
     expect(selectSchema?.kind).toBe('zod-schema-declaration');
@@ -67,7 +67,7 @@ describe('transformDatabaseToZod', () => {
     const program = transformDatabaseToZod(metadata);
 
     const insertSchema = program.declarations.find(
-      (d) => d.kind === 'zod-schema-declaration' && d.name === 'newUserSchema'
+      (d) => d.kind === 'zod-schema-declaration' && d.name === 'newUsersSchema'
     );
     expect(insertSchema).toBeDefined();
     if (insertSchema?.kind === 'zod-schema-declaration' && insertSchema.schema.kind === 'zod-object') {
@@ -96,7 +96,7 @@ describe('transformDatabaseToZod', () => {
     const program = transformDatabaseToZod(metadata);
 
     const updateSchema = program.declarations.find(
-      (d) => d.kind === 'zod-schema-declaration' && d.name === 'userUpdateSchema'
+      (d) => d.kind === 'zod-schema-declaration' && d.name === 'usersUpdateSchema'
     );
     expect(updateSchema).toBeDefined();
     if (updateSchema?.kind === 'zod-schema-declaration' && updateSchema.schema.kind === 'zod-object') {
@@ -128,9 +128,9 @@ describe('transformDatabaseToZod', () => {
     expect(inferExports.length).toBe(3);
 
     const typeNames = inferExports.map((d) => (d as { typeName: string }).typeName);
-    expect(typeNames).toContain('User');
-    expect(typeNames).toContain('NewUser');
-    expect(typeNames).toContain('UserUpdate');
+    expect(typeNames).toContain('Users');
+    expect(typeNames).toContain('NewUsers');
+    expect(typeNames).toContain('UsersUpdate');
   });
 
   test('should handle nullable columns', () => {
@@ -149,7 +149,7 @@ describe('transformDatabaseToZod', () => {
     const program = transformDatabaseToZod(metadata);
 
     const selectSchema = program.declarations.find(
-      (d) => d.kind === 'zod-schema-declaration' && d.name === 'userSchema'
+      (d) => d.kind === 'zod-schema-declaration' && d.name === 'usersSchema'
     );
     if (selectSchema?.kind === 'zod-schema-declaration' && selectSchema.schema.kind === 'zod-object') {
       const bioProp = selectSchema.schema.properties.find((p) => p.name === 'bio');
@@ -176,7 +176,7 @@ describe('transformDatabaseToZod', () => {
     const program = transformDatabaseToZod(metadata);
 
     const selectSchema = program.declarations.find(
-      (d) => d.kind === 'zod-schema-declaration' && d.name === 'userSchema'
+      (d) => d.kind === 'zod-schema-declaration' && d.name === 'usersSchema'
     );
     if (selectSchema?.kind === 'zod-schema-declaration' && selectSchema.schema.kind === 'zod-object') {
       const statusProp = selectSchema.schema.properties.find((p) => p.name === 'status');
@@ -231,12 +231,12 @@ describe('transformDatabaseToZod', () => {
     const code = serializeZod(program);
 
     expect(code).toContain("import { z } from 'zod';");
-    expect(code).toContain('export const userSchema = z.object({');
-    expect(code).toContain('export const newUserSchema = z.object({');
-    expect(code).toContain('export const userUpdateSchema = z.object({');
-    expect(code).toContain('export type User = z.infer<typeof userSchema>;');
-    expect(code).toContain('export type NewUser = z.infer<typeof newUserSchema>;');
-    expect(code).toContain('export type UserUpdate = z.infer<typeof userUpdateSchema>;');
+    expect(code).toContain('export const usersSchema = z.object({');
+    expect(code).toContain('export const newUsersSchema = z.object({');
+    expect(code).toContain('export const usersUpdateSchema = z.object({');
+    expect(code).toContain('export type Users = z.infer<typeof usersSchema>;');
+    expect(code).toContain('export type NewUsers = z.infer<typeof newUsersSchema>;');
+    expect(code).toContain('export type UsersUpdate = z.infer<typeof usersUpdateSchema>;');
   });
 
   test('should generate transform for boolean CHECK constraints by default', () => {


### PR DESCRIPTION
## Summary
- Remove `singularize` function from codebase
- Table/interface names now match database exactly
- Previously: `users` table -> `User` interface
- Now: `users` table -> `Users` interface

Closes #43

## Test plan
- [x] All unit tests pass
- [x] Integration tests pass
- [x] Snapshots updated